### PR TITLE
[NSE-208] Support the hour() expression and add the year(), month() and  dayofmonth() support in String and Timestamp type

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -504,6 +504,7 @@ object ConverterUtils extends Logging {
     case d: StringType =>
     case d: DateType =>
     case d: DecimalType =>
+    case d: TimestampType =>
     case _ =>
       throw new UnsupportedOperationException(s"Unsupported data type: $dt")
   }


### PR DESCRIPTION

## What changes were proposed in this pull request?
This PR add hour() support and also support the string and Timestamp type in year(), month() and dayofmonth() expression in scala side. Fix [#208](https://github.com/oap-project/native-sql-engine/issues/208)

## How was this patch tested?
pass the test in DateFunctionsSuite# test("hour") 


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

