### PR TITLE
[NSE-417] Sort spill support framework

### DIFF
--- a/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -145,6 +145,8 @@ public class ExpressionEvaluatorJniWrapper {
         native ArrowRecordBatchBuilder[] nativeEvaluate(long nativeHandler, int numRows, long[] bufAddrs,
                         long[] bufSizes) throws RuntimeException;
 
+       native ArrowRecordBatchBuilder[] nativeEvaluate2(long nativeHandler, byte[] bytes) throws RuntimeException;
+
         /**
          * Get native kernel signature by the nativeHandler.
          *

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/ColumnarPlugin.scala
@@ -112,8 +112,6 @@ case class ColumnarPreOverrides() extends Rule[SparkPlan] {
       val child = replaceWithColumnarPlan(plan.child)
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
       child match {
-        case CoalesceBatchesExec(fwdChild: SparkPlan) =>
-          ColumnarSortExec(plan.sortOrder, plan.global, fwdChild, plan.testSpillFrequency)
         case _ =>
           ColumnarSortExec(plan.sortOrder, plan.global, child, plan.testSpillFrequency)
       }

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -373,7 +373,7 @@ object ColumnarSorter extends Logging {
     val (sort_expr, arrowSchema) = init(sortOrder, outputAttributes, sparkConf)
     val sorter = new ExpressionEvaluator()
     val signature = sorter
-      .build(arrowSchema, Lists.newArrayList(sort_expr), arrowSchema, true /*return at finish*/ )
+      .build(arrowSchema, Lists.newArrayList(sort_expr), arrowSchema, true /*return at finish*/)
     sorter.close
     signature
   }
@@ -391,7 +391,7 @@ object ColumnarSorter extends Logging {
     val (sort_expr, arrowSchema) = init(sortOrder, outputAttributes, sparkConf)
     val sorter = new ExpressionEvaluator(listJars.toList.asJava)
     sorter
-      .build(arrowSchema, Lists.newArrayList(sort_expr), arrowSchema, true /*return at finish*/ )
+      .build(arrowSchema, Lists.newArrayList(sort_expr), arrowSchema, true /*return at finish*/, true/*enable spill*/)
     new ColumnarSorter(
       sorter,
       outputAttributes,

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -92,8 +92,8 @@ class ColumnarSorter(
     elapse.set(NANOSECONDS.toMillis(total_elapse))
     sortTime.set(NANOSECONDS.toMillis(sort_elapse))
     shuffleTime.set(NANOSECONDS.toMillis(shuffle_elapse))
-    inputBatchHolder.foreach(cb => cb.close())
-    inputBatchHolder.clear
+    //inputBatchHolder.foreach(cb => cb.close())
+    //inputBatchHolder.clear
     if (sorter != null) {
       sorter.close()
     }
@@ -110,7 +110,7 @@ class ColumnarSorter(
     (0 until input.numCols).toList.foreach(i =>
       input.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
     val beforeSort = System.nanoTime()
-    sorter.evaluate(input_batch)
+    sorter.evaluate2(input_batch)
     sort_elapse += System.nanoTime() - beforeSort
     total_elapse += System.nanoTime() - beforeSort
     ConverterUtils.releaseArrowRecordBatch(input_batch)
@@ -160,8 +160,8 @@ class ColumnarSorter(
           return true
         } else {
           has_next = false
-          inputBatchHolder.foreach(cb => cb.close())
-          inputBatchHolder.clear
+          //inputBatchHolder.foreach(cb => cb.close())
+          //inputBatchHolder.clear
           return false
         }
       }

--- a/native-sql-engine/cpp/compile.sh
+++ b/native-sql-engine/cpp/compile.sh
@@ -21,13 +21,13 @@ CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 echo $CURRENT_DIR
 
 cd ${CURRENT_DIR}
-#if [ -d build ]; then
-#    rm -r build
-#fi
-#mkdir build
+if [ -d build ]; then
+    rm -r build
+fi
+mkdir build
 cd build
 cmake .. -DTESTS=${TESTS} -DBUILD_ARROW=${BUILD_ARROW} -DSTATIC_ARROW=${STATIC_ARROW} -DBUILD_PROTOBUF=${BUILD_PROTOBUF} -DARROW_ROOT=${ARROW_ROOT} -DARROW_BFS_INSTALL_DIR=${ARROW_BFS_INSTALL_DIR}
-make -j
+make -j2
 
 set +eu
 

--- a/native-sql-engine/cpp/compile.sh
+++ b/native-sql-engine/cpp/compile.sh
@@ -21,13 +21,13 @@ CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 echo $CURRENT_DIR
 
 cd ${CURRENT_DIR}
-if [ -d build ]; then
-    rm -r build
-fi
-mkdir build
+#if [ -d build ]; then
+#    rm -r build
+#fi
+#mkdir build
 cd build
 cmake .. -DTESTS=${TESTS} -DBUILD_ARROW=${BUILD_ARROW} -DSTATIC_ARROW=${STATIC_ARROW} -DBUILD_PROTOBUF=${BUILD_PROTOBUF} -DARROW_ROOT=${ARROW_ROOT} -DARROW_BFS_INSTALL_DIR=${ARROW_BFS_INSTALL_DIR}
-make
+make -j
 
 set +eu
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
@@ -114,7 +114,7 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
     return arrow::Status::OK();
   }
 
-  arrow::Status evaluate(const std::shared_ptr<arrow::RecordBatch>& in,
+  arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
     arrow::Status status = arrow::Status::OK();
     std::vector<ArrayList> batch_array;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
@@ -116,7 +116,6 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
 
   arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
-    std::cout << "codegen cnt:" << in.use_count() << std::endl;
     arrow::Status status = arrow::Status::OK();
     std::vector<ArrayList> batch_array;
     std::vector<int> batch_size_array;
@@ -255,7 +254,6 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
       *spilled_size = 0L;
       return arrow::Status::OK();
     }
-    std::cout << "xxx1: " << size << std::endl;
     int64_t current_spilled = 0L;
     for (auto visitor : visitor_list_) {
       int64_t single_call_spilled = 0;
@@ -263,13 +261,11 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
       current_spilled += single_call_spilled;
       if (current_spilled >= size) {
         *spilled_size = current_spilled;
-        std::cout << "xxx2: " << *spilled_size << std::endl;
         return arrow::Status::OK();
       }
     }
 
     *spilled_size = current_spilled;
-    std::cout << "xxx3: " << *spilled_size << std::endl;
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
@@ -114,7 +114,7 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
     return arrow::Status::OK();
   }
 
-  arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
+  arrow::Status evaluate(std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
     arrow::Status status = arrow::Status::OK();
     std::vector<ArrayList> batch_array;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/code_generator.h
@@ -116,6 +116,7 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
 
   arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
+    std::cout << "codegen cnt:" << in.use_count() << std::endl;
     arrow::Status status = arrow::Status::OK();
     std::vector<ArrayList> batch_array;
     std::vector<int> batch_size_array;
@@ -254,17 +255,21 @@ class ArrowComputeCodeGenerator : public CodeGenerator {
       *spilled_size = 0L;
       return arrow::Status::OK();
     }
+    std::cout << "xxx1: " << size << std::endl;
     int64_t current_spilled = 0L;
     for (auto visitor : visitor_list_) {
-      int64_t single_call_spilled;
+      int64_t single_call_spilled = 0;
       RETURN_NOT_OK(visitor->Spill(size - current_spilled, &single_call_spilled));
       current_spilled += single_call_spilled;
       if (current_spilled >= size) {
         *spilled_size = current_spilled;
+        std::cout << "xxx2: " << *spilled_size << std::endl;
         return arrow::Status::OK();
       }
     }
+
     *spilled_size = current_spilled;
+    std::cout << "xxx3: " << *spilled_size << std::endl;
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -519,6 +519,8 @@ arrow::Status ExprVisitor::Eval(const std::shared_ptr<arrow::Array>& selection_i
 
 arrow::Status ExprVisitor::Eval( std::shared_ptr<arrow::RecordBatch>& in) {
   in_record_batch_ = std::move(in);
+  //std::cout << "in eval cnt: " << (in_record_batch_->columns()[0]).use_count() << "\n";
+  std::cout << "in eval cnt: " << (in_record_batch_).use_count() << "\n";
   RETURN_NOT_OK(Eval());
   return arrow::Status::OK();
 }
@@ -757,23 +759,28 @@ arrow::Status ExprVisitor::GetResult(
 }
 
 arrow::Status ExprVisitor::Spill(int64_t size, int64_t* spilled_size) {
-  int64_t current_spilled = 0L;
+  int64_t current_spilled = 0;
   if (dependency_) {
     // fixme cycle invocation?
-    int64_t single_call_spilled;
+    int64_t single_call_spilled = 0;
     RETURN_NOT_OK(dependency_->Spill(size - current_spilled, &single_call_spilled));
     current_spilled += single_call_spilled;
+
     if (current_spilled >= size) {
       *spilled_size = current_spilled;
+      std::cout << "yyy0: " << *spilled_size << std::endl;
       return arrow::Status::OK();
     }
   }
+  std::cout << "yyy: " << current_spilled << std::endl;
   if (!finish_visitor_) {
-    int64_t single_call_spilled;
+    int64_t single_call_spilled = 0;
     RETURN_NOT_OK(impl_->Spill(size - current_spilled, &single_call_spilled));
     current_spilled += single_call_spilled;
+        std::cout << "yyy1: " << current_spilled << std::endl;
   }
   *spilled_size = current_spilled;
+  std::cout << "yyy3: " << *spilled_size << std::endl;
   return arrow::Status::OK();
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -517,7 +517,7 @@ arrow::Status ExprVisitor::Eval(const std::shared_ptr<arrow::Array>& selection_i
   return arrow::Status::OK();
 }
 
-arrow::Status ExprVisitor::Eval( std::shared_ptr<arrow::RecordBatch>& in) {
+arrow::Status ExprVisitor::Eval(std::shared_ptr<arrow::RecordBatch>& in) {
   in_record_batch_ = std::move(in);
   RETURN_NOT_OK(Eval());
   return arrow::Status::OK();

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -519,8 +519,6 @@ arrow::Status ExprVisitor::Eval(const std::shared_ptr<arrow::Array>& selection_i
 
 arrow::Status ExprVisitor::Eval( std::shared_ptr<arrow::RecordBatch>& in) {
   in_record_batch_ = std::move(in);
-  //std::cout << "in eval cnt: " << (in_record_batch_->columns()[0]).use_count() << "\n";
-  std::cout << "in eval cnt: " << (in_record_batch_).use_count() << "\n";
   RETURN_NOT_OK(Eval());
   return arrow::Status::OK();
 }
@@ -768,19 +766,15 @@ arrow::Status ExprVisitor::Spill(int64_t size, int64_t* spilled_size) {
 
     if (current_spilled >= size) {
       *spilled_size = current_spilled;
-      std::cout << "yyy0: " << *spilled_size << std::endl;
       return arrow::Status::OK();
     }
   }
-  std::cout << "yyy: " << current_spilled << std::endl;
   if (!finish_visitor_) {
     int64_t single_call_spilled = 0;
     RETURN_NOT_OK(impl_->Spill(size - current_spilled, &single_call_spilled));
     current_spilled += single_call_spilled;
-        std::cout << "yyy1: " << current_spilled << std::endl;
   }
   *spilled_size = current_spilled;
-  std::cout << "yyy3: " << *spilled_size << std::endl;
   return arrow::Status::OK();
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.cc
@@ -517,8 +517,8 @@ arrow::Status ExprVisitor::Eval(const std::shared_ptr<arrow::Array>& selection_i
   return arrow::Status::OK();
 }
 
-arrow::Status ExprVisitor::Eval(const std::shared_ptr<arrow::RecordBatch>& in) {
-  in_record_batch_ = in;
+arrow::Status ExprVisitor::Eval( std::shared_ptr<arrow::RecordBatch>& in) {
+  in_record_batch_ = std::move(in);
   RETURN_NOT_OK(Eval());
   return arrow::Status::OK();
 }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.h
@@ -190,6 +190,7 @@ class ExprVisitor : public std::enable_shared_from_this<ExprVisitor> {
   std::shared_ptr<ExprVisitor> dependency_;
   std::shared_ptr<arrow::Array> in_selection_array_;
   std::shared_ptr<arrow::RecordBatch> in_record_batch_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> in_record_batch_holder_;
   std::vector<std::shared_ptr<arrow::Field>> ret_fields_;
 
   // For dual input kernels like probe

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.h
@@ -152,7 +152,7 @@ class ExprVisitor : public std::enable_shared_from_this<ExprVisitor> {
   arrow::Status Init();
   arrow::Status Eval(const std::shared_ptr<arrow::Array>& selection_in,
                      const std::shared_ptr<arrow::RecordBatch>& in);
-  arrow::Status Eval( std::shared_ptr<arrow::RecordBatch>& in);
+  arrow::Status Eval(std::shared_ptr<arrow::RecordBatch>& in);
   arrow::Status Eval();
   std::string GetSignature() { return signature_; }
   arrow::Status SetMember(const std::shared_ptr<arrow::RecordBatch>& ms);

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor.h
@@ -152,7 +152,7 @@ class ExprVisitor : public std::enable_shared_from_this<ExprVisitor> {
   arrow::Status Init();
   arrow::Status Eval(const std::shared_ptr<arrow::Array>& selection_in,
                      const std::shared_ptr<arrow::RecordBatch>& in);
-  arrow::Status Eval(const std::shared_ptr<arrow::RecordBatch>& in);
+  arrow::Status Eval( std::shared_ptr<arrow::RecordBatch>& in);
   arrow::Status Eval();
   std::string GetSignature() { return signature_; }
   arrow::Status SetMember(const std::shared_ptr<arrow::RecordBatch>& ms);

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -511,15 +511,11 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
 
   arrow::Status Spill(int64_t size, int64_t* spilled_size) override {
     std::cout << "target size: " << size << std::endl;
-    RETURN_NOT_OK(kernel_->Spill(spilled_size));
+    RETURN_NOT_OK(kernel_->Spill(size, spilled_size));
 
-    if ((p_->in_record_batch_holder_).size() == 0) {
-      *spilled_size = 0;
-    } else {
+    if (*spilled_size != 0) {
       (p_->in_record_batch_holder_).clear();
-      *spilled_size = size;
     }
-
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -510,13 +510,16 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
   }
 
   arrow::Status Spill(int64_t size, int64_t* spilled_size) override {
+    std::cout << "target size: " << size << std::endl;
     RETURN_NOT_OK(kernel_->Spill(spilled_size));
-    auto memory_size_start = arrow::default_memory_pool()->bytes_allocated();
-    (p_->in_record_batch_holder_).clear();
-    auto memory_size_end = arrow::default_memory_pool()->bytes_allocated();
-    int64_t diff = memory_size_start - memory_size_end;
-    std::cout << "spill size: " << diff << std::endl;
-    *spilled_size = diff;
+
+    if ((p_->in_record_batch_holder_).size() == 0) {
+      *spilled_size = 0;
+    } else {
+      (p_->in_record_batch_holder_).clear();
+      *spilled_size = size;
+    }
+    
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -494,11 +494,11 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
   arrow::Status Eval() override {
     switch (p_->dependency_result_type_) {
       case ArrowComputeResultType::None: {
-        std::cout << "in sort EVAL cnt:" << ((p_->in_record_batch_)).use_count() << "\n";
         std::vector<std::shared_ptr<arrow::Array>> col_list;
         for (auto col : p_->in_record_batch_->columns()) {
           col_list.push_back(std::move(col));
         }
+        p_->in_record_batch_holder_.push_back(std::move(p_->in_record_batch_));
         RETURN_NOT_OK(kernel_->Evaluate(col_list));
       } break;
       default:
@@ -510,13 +510,13 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
   }
 
   arrow::Status Spill(int64_t size, int64_t* spilled_size) override {
-    std::cout << "target spill: " << size << std::endl;
-    std::cout << "mempool size: " << arrow::default_memory_pool()->bytes_allocated() << "\n";
     RETURN_NOT_OK(kernel_->Spill(spilled_size));
-    std::cout << "actual use cnt: " << ((p_->in_record_batch_)->columns()[0]).use_count() << std::endl;
-    p_->in_record_batch_.reset();
-    std::cout << "actual spill: " << *spilled_size << std::endl;
-    std::cout << "mempool size: " << arrow::default_memory_pool()->bytes_allocated() << "\n";
+    auto memory_size_start = arrow::default_memory_pool()->bytes_allocated();
+    (p_->in_record_batch_holder_).clear();
+    auto memory_size_end = arrow::default_memory_pool()->bytes_allocated();
+    int64_t diff = memory_size_start - memory_size_end;
+    std::cout << "spill size: " << diff << std::endl;
+    *spilled_size = diff;
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -519,7 +519,7 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
       (p_->in_record_batch_holder_).clear();
       *spilled_size = size;
     }
-    
+
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -508,6 +508,13 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
     return arrow::Status::OK();
   }
 
+  arrow::Status Spill(int64_t size, int64_t* spilled_size) override {
+
+    RETURN_NOT_OK(kernel_->Spill(spilled_size));
+
+    return arrow::Status::OK();
+  }
+
   arrow::Status MakeResultIterator(std::shared_ptr<arrow::Schema> schema,
                                    std::shared_ptr<ResultIteratorBase>* out) override {
     switch (finish_return_type_) {

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -731,7 +731,7 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
     return arrow::Status::OK();
   }
   arrow::Status ClearArrays() override {
-    std::cout << "clear array\n";
+
     cached_arr_.clear();
     has_null_ = false;
     return arrow::Status::OK();
@@ -781,14 +781,7 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
   }
 
   arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
-
     auto status = builder_->Finish(out_);
-    // std::cout << "before |" << arrow::default_memory_pool()->bytes_allocated() << "\n";
-    // for(auto i = 0; i< cached_arr_.size(); i++) {
-    //   std::cout << "append use cnt: " << cached_arr_[i].use_count() << std::endl;
-    //   cached_arr_[i].reset();
-    // }
-    // std::cout << "after |" << arrow::default_memory_pool()->bytes_allocated() << "\n";
     return status;
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -718,7 +718,6 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
   AppenderType GetType() override { return type_; }
 
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
-
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     cached_arr_.push_back(typed_arr_);
@@ -731,7 +730,6 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
     return arrow::Status::OK();
   }
   arrow::Status ClearArrays() override {
-
     cached_arr_.clear();
     has_null_ = false;
     return arrow::Status::OK();

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -47,6 +47,10 @@ class AppenderBase {
     return arrow::Status::NotImplemented("AppenderBase PopArray is abstract.");
   }
 
+  virtual arrow::Status ClearArrays() {
+    return arrow::Status::NotImplemented("AppenderBase ClearArrays is abstract.");
+  }
+
   virtual arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) {
     return arrow::Status::NotImplemented("AppenderBase Append is abstract.");
   }
@@ -108,13 +112,19 @@ class ArrayAppender<DataType, enable_if_timestamp<DataType>> : public AppenderBa
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
 
   arrow::Status PopArray() override {
     cached_arr_.pop_back();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
     has_null_ = false;
     return arrow::Status::OK();
   }
@@ -198,7 +208,7 @@ class ArrayAppender<DataType, enable_if_number_or_date<DataType>> : public Appen
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -208,7 +218,11 @@ class ArrayAppender<DataType, enable_if_number_or_date<DataType>> : public Appen
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -285,7 +299,7 @@ class ArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -295,7 +309,11 @@ class ArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -370,7 +388,7 @@ class ArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public Appen
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -380,7 +398,11 @@ class ArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public Appen
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -457,7 +479,7 @@ class ArrayAppender<DataType, enable_if_decimal<DataType>> : public AppenderBase
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -467,7 +489,11 @@ class ArrayAppender<DataType, enable_if_decimal<DataType>> : public AppenderBase
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
       RETURN_NOT_OK(builder_->AppendNull());
@@ -590,7 +616,7 @@ class UnsafeArrayAppender<DataType, enable_if_timestamp<DataType>> : public Appe
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -600,7 +626,11 @@ class UnsafeArrayAppender<DataType, enable_if_timestamp<DataType>> : public Appe
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -686,10 +716,12 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
   ~UnsafeArrayAppender() {}
 
   AppenderType GetType() override { return type_; }
+
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
+
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
+    cached_arr_.push_back(typed_arr_);
     return arrow::Status::OK();
   }
 
@@ -698,7 +730,12 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    std::cout << "clear array\n";
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -744,7 +781,14 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
   }
 
   arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
+
     auto status = builder_->Finish(out_);
+    // std::cout << "before |" << arrow::default_memory_pool()->bytes_allocated() << "\n";
+    // for(auto i = 0; i< cached_arr_.size(); i++) {
+    //   std::cout << "append use cnt: " << cached_arr_[i].use_count() << std::endl;
+    //   cached_arr_[i].reset();
+    // }
+    // std::cout << "after |" << arrow::default_memory_pool()->bytes_allocated() << "\n";
     return status;
   }
 
@@ -786,7 +830,7 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -796,7 +840,11 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -878,7 +926,7 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_boolean<DataType>>
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -888,7 +936,11 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_boolean<DataType>>
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
@@ -971,7 +1023,7 @@ class UnsafeArrayAppender<DataType, enable_if_decimal<DataType>> : public Append
   AppenderType GetType() override { return type_; }
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
-    cached_arr_.emplace_back(typed_arr_);
+    cached_arr_.push_back(typed_arr_);
     if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
@@ -981,7 +1033,11 @@ class UnsafeArrayAppender<DataType, enable_if_decimal<DataType>> : public Append
     has_null_ = false;
     return arrow::Status::OK();
   }
-
+  arrow::Status ClearArrays() override {
+    cached_arr_.clear();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
   arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
     if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
       builder_->UnsafeAppendNull();

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/code_generator_base.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/code_generator_base.h
@@ -29,7 +29,7 @@ namespace extra {
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
 class CodeGenBase {
  public:
-   virtual arrow::Status Evaluate(ArrayList& in) {
+  virtual arrow::Status Evaluate(ArrayList& in) {
     return arrow::Status::NotImplemented(
         "CodeGenBase Evaluate is an abstract interface.");
   }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/code_generator_base.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/code_generator_base.h
@@ -29,6 +29,10 @@ namespace extra {
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
 class CodeGenBase {
  public:
+   virtual arrow::Status Evaluate(ArrayList& in) {
+    return arrow::Status::NotImplemented(
+        "CodeGenBase Evaluate is an abstract interface.");
+  }
   virtual arrow::Status Evaluate(const ArrayList& in) {
     return arrow::Status::NotImplemented(
         "CodeGenBase Evaluate is an abstract interface.");

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
@@ -154,7 +154,7 @@ class HashRelationKernel::Impl {
 
   ~Impl() {}
 
-  arrow::Status Evaluate(const ArrayList& in) {
+  arrow::Status Evaluate( ArrayList& in) {
     if (in.size() > 0) num_total_cached_ += in[0]->length();
     for (int i = 0; i < in.size(); i++) {
       RETURN_NOT_OK(hash_relation_->AppendPayloadColumn(i, in[i]));
@@ -346,7 +346,7 @@ HashRelationKernel::HashRelationKernel(
   kernel_name_ = "HashRelationKernel";
 }
 
-arrow::Status HashRelationKernel::Evaluate(const ArrayList& in) {
+arrow::Status HashRelationKernel::Evaluate( ArrayList& in) {
   return impl_->Evaluate(in);
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
@@ -154,7 +154,7 @@ class HashRelationKernel::Impl {
 
   ~Impl() {}
 
-  arrow::Status Evaluate( ArrayList& in) {
+  arrow::Status Evaluate(ArrayList& in) {
     if (in.size() > 0) num_total_cached_ += in[0]->length();
     for (int i = 0; i < in.size(); i++) {
       RETURN_NOT_OK(hash_relation_->AppendPayloadColumn(i, in[i]));
@@ -346,9 +346,7 @@ HashRelationKernel::HashRelationKernel(
   kernel_name_ = "HashRelationKernel";
 }
 
-arrow::Status HashRelationKernel::Evaluate( ArrayList& in) {
-  return impl_->Evaluate(in);
-}
+arrow::Status HashRelationKernel::Evaluate(ArrayList& in) { return impl_->Evaluate(in); }
 
 arrow::Status HashRelationKernel::MakeResultIterator(
     std::shared_ptr<arrow::Schema> schema,

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -339,7 +339,7 @@ class CachedRelationKernel::Impl {
     col_num_ = result_schema->num_fields();
   }
 
-  arrow::Status Evaluate(const ArrayList& in) {
+  arrow::Status Evaluate( ArrayList& in) {
     items_total_ += in[0]->length();
     length_list_.push_back(in[0]->length());
     if (cached_.size() < col_num_) {
@@ -420,7 +420,7 @@ CachedRelationKernel::CachedRelationKernel(
   kernel_name_ = "CachedRelationKernel";
 }
 
-arrow::Status CachedRelationKernel::Evaluate(const ArrayList& in) {
+arrow::Status CachedRelationKernel::Evaluate( ArrayList& in) {
   return impl_->Evaluate(in);
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -339,7 +339,7 @@ class CachedRelationKernel::Impl {
     col_num_ = result_schema->num_fields();
   }
 
-  arrow::Status Evaluate( ArrayList& in) {
+  arrow::Status Evaluate(ArrayList& in) {
     items_total_ += in[0]->length();
     length_list_.push_back(in[0]->length());
     if (cached_.size() < col_num_) {
@@ -420,7 +420,7 @@ CachedRelationKernel::CachedRelationKernel(
   kernel_name_ = "CachedRelationKernel";
 }
 
-arrow::Status CachedRelationKernel::Evaluate( ArrayList& in) {
+arrow::Status CachedRelationKernel::Evaluate(ArrayList& in) {
   return impl_->Evaluate(in);
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -39,6 +39,10 @@ class KernalBase {
  public:
   KernalBase() {}
   virtual ~KernalBase() {}
+  virtual arrow::Status Evaluate(ArrayList& in) {
+      return arrow::Status::NotImplemented("Evaluate is abstract interface for ",
+                                         kernel_name_, ", input is arrayList.");
+  }
   virtual arrow::Status Evaluate(const ArrayList& in) {
     return arrow::Status::NotImplemented("Evaluate is abstract interface for ",
                                          kernel_name_, ", input is arrayList.");
@@ -197,7 +201,7 @@ class SortArraysToIndicesKernel : public KernalBase {
                             std::vector<bool> sort_directions,
                             std::vector<bool> nulls_order, bool NaN_check,
                             bool do_codegen, int result_type);
-  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Evaluate(ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -382,7 +382,7 @@ class ConditionedJoinArraysKernel : public KernalBase {
       const std::vector<std::shared_ptr<arrow::Field>>& left_field_list,
       const std::vector<std::shared_ptr<arrow::Field>>& right_field_list,
       const std::shared_ptr<arrow::Schema>& result_schema);
-  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Evaluate( ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -136,7 +136,7 @@ class WindowAggregateFunctionKernel : public KernalBase {
                             std::vector<std::shared_ptr<arrow::DataType>> type_list,
                             std::shared_ptr<arrow::DataType> result_type,
                             std::shared_ptr<KernalBase>* out);
-  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Evaluate( ArrayList& in) override;
   arrow::Status Finish(ArrayList* out) override;
 
  private:
@@ -227,7 +227,7 @@ class CachedRelationKernel : public KernalBase {
                        std::shared_ptr<arrow::Schema> result_schema,
                        std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                        int result_type);
-  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Evaluate( ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<SortRelation>>* out) override;
@@ -298,7 +298,7 @@ class WindowRankKernel : public KernalBase {
   static arrow::Status Make(arrow::compute::ExecContext* ctx, std::string function_name,
                             std::vector<std::shared_ptr<arrow::DataType>> type_list,
                             std::shared_ptr<KernalBase>* out, bool desc);
-  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Evaluate( ArrayList& in) override;
   arrow::Status Finish(ArrayList* out) override;
 
   arrow::Status SortToIndicesPrepare(std::vector<ArrayList> values);
@@ -429,7 +429,7 @@ class HashRelationKernel : public KernalBase {
                      const std::vector<std::shared_ptr<arrow::Field>>& input_field_list,
                      std::shared_ptr<gandiva::Node> root_node,
                      const std::vector<std::shared_ptr<arrow::Field>>& output_field_list);
-  arrow::Status Evaluate(const ArrayList& in) override;
+  arrow::Status Evaluate( ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<HashRelation>>* out) override;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -39,12 +39,12 @@ class KernalBase {
  public:
   KernalBase() {}
   virtual ~KernalBase() {}
-    virtual arrow::Status Spill(int64_t* spilled_size) {
-      return arrow::Status::NotImplemented("Spill is abstract interface for ",
-                                         kernel_name_, ", output is spill size");
+  virtual arrow::Status Spill(int64_t* spilled_size) {
+    return arrow::Status::NotImplemented("Spill is abstract interface for ", kernel_name_,
+                                         ", output is spill size");
   }
   virtual arrow::Status Evaluate(ArrayList& in) {
-      return arrow::Status::NotImplemented("Evaluate is abstract interface for ",
+    return arrow::Status::NotImplemented("Evaluate is abstract interface for ",
                                          kernel_name_, ", input is arrayList.");
   }
   virtual arrow::Status Evaluate(const ArrayList& in) {
@@ -140,7 +140,7 @@ class WindowAggregateFunctionKernel : public KernalBase {
                             std::vector<std::shared_ptr<arrow::DataType>> type_list,
                             std::shared_ptr<arrow::DataType> result_type,
                             std::shared_ptr<KernalBase>* out);
-  arrow::Status Evaluate( ArrayList& in) override;
+  arrow::Status Evaluate(ArrayList& in) override;
   arrow::Status Finish(ArrayList* out) override;
 
  private:
@@ -232,7 +232,7 @@ class CachedRelationKernel : public KernalBase {
                        std::shared_ptr<arrow::Schema> result_schema,
                        std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                        int result_type);
-  arrow::Status Evaluate( ArrayList& in) override;
+  arrow::Status Evaluate(ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<SortRelation>>* out) override;
@@ -303,7 +303,7 @@ class WindowRankKernel : public KernalBase {
   static arrow::Status Make(arrow::compute::ExecContext* ctx, std::string function_name,
                             std::vector<std::shared_ptr<arrow::DataType>> type_list,
                             std::shared_ptr<KernalBase>* out, bool desc);
-  arrow::Status Evaluate( ArrayList& in) override;
+  arrow::Status Evaluate(ArrayList& in) override;
   arrow::Status Finish(ArrayList* out) override;
 
   arrow::Status SortToIndicesPrepare(std::vector<ArrayList> values);
@@ -387,7 +387,7 @@ class ConditionedJoinArraysKernel : public KernalBase {
       const std::vector<std::shared_ptr<arrow::Field>>& left_field_list,
       const std::vector<std::shared_ptr<arrow::Field>>& right_field_list,
       const std::shared_ptr<arrow::Schema>& result_schema);
-  arrow::Status Evaluate( ArrayList& in) override;
+  arrow::Status Evaluate(ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;
@@ -434,7 +434,7 @@ class HashRelationKernel : public KernalBase {
                      const std::vector<std::shared_ptr<arrow::Field>>& input_field_list,
                      std::shared_ptr<gandiva::Node> root_node,
                      const std::vector<std::shared_ptr<arrow::Field>>& output_field_list);
-  arrow::Status Evaluate( ArrayList& in) override;
+  arrow::Status Evaluate(ArrayList& in) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<HashRelation>>* out) override;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -39,6 +39,10 @@ class KernalBase {
  public:
   KernalBase() {}
   virtual ~KernalBase() {}
+    virtual arrow::Status Spill(int64_t* spilled_size) {
+      return arrow::Status::NotImplemented("Spill is abstract interface for ",
+                                         kernel_name_, ", output is spill size");
+  }
   virtual arrow::Status Evaluate(ArrayList& in) {
       return arrow::Status::NotImplemented("Evaluate is abstract interface for ",
                                          kernel_name_, ", input is arrayList.");
@@ -202,6 +206,7 @@ class SortArraysToIndicesKernel : public KernalBase {
                             std::vector<bool> nulls_order, bool NaN_check,
                             bool do_codegen, int result_type);
   arrow::Status Evaluate(ArrayList& in) override;
+  arrow::Status Spill(int64_t*) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -39,7 +39,7 @@ class KernalBase {
  public:
   KernalBase() {}
   virtual ~KernalBase() {}
-  virtual arrow::Status Spill(int64_t* spilled_size) {
+  virtual arrow::Status Spill(int64_t size, int64_t* spilled_size) {
     return arrow::Status::NotImplemented("Spill is abstract interface for ", kernel_name_,
                                          ", output is spill size");
   }
@@ -206,7 +206,7 @@ class SortArraysToIndicesKernel : public KernalBase {
                             std::vector<bool> nulls_order, bool NaN_check,
                             bool do_codegen, int result_type);
   arrow::Status Evaluate(ArrayList& in) override;
-  arrow::Status Spill(int64_t*) override;
+  arrow::Status Spill(int64_t, int64_t*) override;
   arrow::Status MakeResultIterator(
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<ResultIterator<arrow::RecordBatch>>* out) override;

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/merge_join_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/merge_join_kernel.cc
@@ -1511,7 +1511,7 @@ ConditionedJoinArraysKernel::ConditionedJoinArraysKernel(
   kernel_name_ = "ConditionedJoinArraysKernel";
 }
 
-arrow::Status ConditionedJoinArraysKernel::Evaluate(const ArrayList& in) {
+arrow::Status ConditionedJoinArraysKernel::Evaluate( ArrayList& in) {
   return impl_->Evaluate(in);
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/merge_join_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/merge_join_kernel.cc
@@ -1511,7 +1511,7 @@ ConditionedJoinArraysKernel::ConditionedJoinArraysKernel(
   kernel_name_ = "ConditionedJoinArraysKernel";
 }
 
-arrow::Status ConditionedJoinArraysKernel::Evaluate( ArrayList& in) {
+arrow::Status ConditionedJoinArraysKernel::Evaluate(ArrayList& in) {
   return impl_->Evaluate(in);
 }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -220,6 +220,11 @@ class SortArraysToIndicesKernel::Impl {
 
     return arrow::Status::OK();
   }
+    
+  virtual arrow::Status Spill(int64_t* spilled_size)  {
+    // do spill
+    return arrow::Status::OK();
+  }
 
   std::string random_string(size_t length) {
     auto randchar = []() -> char {
@@ -1347,6 +1352,11 @@ class SortOnekeyKernel : public SortArraysToIndicesKernel::Impl {
     return arrow::Status::OK();
   }
 
+  arrow::Status Spill(int64_t* spilled_size)  {
+    // do spill
+    return arrow::Status::OK();
+  }
+
   std::string random_string(size_t length) {
     auto randchar = []() -> char {
       const char charset[] =
@@ -2040,6 +2050,10 @@ SortArraysToIndicesKernel::SortArraysToIndicesKernel(
 
 arrow::Status SortArraysToIndicesKernel::Evaluate(ArrayList& in) {
   return impl_->Evaluate(in);
+}
+
+arrow::Status SortArraysToIndicesKernel::Spill(int64_t* spilled_size) {
+  return impl_->Spill(spilled_size);
 }
 
 arrow::Status SortArraysToIndicesKernel::MakeResultIterator(

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -258,7 +258,7 @@ class SortArraysToIndicesKernel::Impl {
     }
 
     ~SpillableCacheStore() {
-      for (auto& file_path: spill_file_list) {
+      for (auto& file_path : spill_file_list) {
         std::remove(file_path.c_str());
       }
       std::remove(local_spill_dir_.c_str());
@@ -842,7 +842,7 @@ extern "C" void MakeCodeGen(arrow::compute::ExecContext* ctx,
       std::cout << "call on: " << spillablecachestore_->GetSpillDir() << "|"
                 << is_spilled_ << "\n";
       if (is_spilled_) {
-        //TODO: this should be fixed when spill in sorting
+        // TODO: this should be fixed when spill in sorting
         *spilled_size = 0;
         return arrow::Status::OK();
       }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -211,12 +211,14 @@ class SortArraysToIndicesKernel::Impl {
 
     if (1) {
       Spill(in);
+      //std::cout << "before: " << arrow::default_memory_pool()->bytes_allocated() <<std::endl;
       for (int i = 0; i < in.size(); i++) {
         if (std::find(key_index_list_.begin(), key_index_list_.end(), i) ==
             key_index_list_.end()) {
           in[i].reset();
         }
       }
+      //std::cout << "after: " << arrow::default_memory_pool()->bytes_allocated() <<std::endl;
     } else {
       for (int i = 0; i < col_num_; i++) {
         cached_[i].push_back(in[i]);
@@ -1349,12 +1351,13 @@ class SortOnekeyKernel : public SortArraysToIndicesKernel::Impl {
     // TODO(): a flag to enable/disable spill
     if (1) {
       Spill(in);
-
+      //std::cout << "onekey before: " << arrow::default_memory_pool()->bytes_allocated() <<std::endl;
       for (int i = 0; i < in.size(); i++) {
         if (i != key_id_) {
           in[i].reset();
         }
       }
+      //std::cout << "onekeyafter: " << arrow::default_memory_pool()->bytes_allocated() <<std::endl;
     } else {
       for (int i = 0; i < col_num_; i++) {
         cached_[i].push_back(in[i]);

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -842,7 +842,15 @@ extern "C" void MakeCodeGen(arrow::compute::ExecContext* ctx,
 
     arrow::Status SortResultSpill() {
       //TODO(): write to local disk
-      spillablecachestore_ = std::make_shared<SpillableCacheStore>(cached_in_, schema_);
+
+      if (!spillablecachestore_) {
+        spillablecachestore_ = std::make_shared<SpillableCacheStore>(cached_in_, schema_);
+      }
+      std::cout << "call on: " << spillablecachestore_->GetSpillDir() << "|" << is_spilled_ <<"\n";
+      if (is_spilled_) {
+        return arrow::Status::OK();
+      }
+
       spillablecachestore_->DoSpill();
 
       //clean up references on cached array

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 #include <arrow/array/concatenate.h>
 #include <arrow/compute/api.h>
 #include <arrow/io/file.h>
@@ -137,6 +140,8 @@ class SortArraysToIndicesKernel::Impl {
         throw;
       }
     }
+
+    //TODO(): create spill dir
   }
 
   virtual ~Impl() {}
@@ -226,6 +231,11 @@ class SortArraysToIndicesKernel::Impl {
     return arrow::Status::OK();
   }
 
+  std::string GenerateUUID() {
+    boost::uuids::random_generator generator;
+    return boost::uuids::to_string(generator());
+  }
+
   std::string random_string(size_t length) {
     auto randchar = []() -> char {
       const char charset[] =
@@ -248,7 +258,7 @@ class SortArraysToIndicesKernel::Impl {
     arrow::ipc::DictionaryFieldMapper dict_file_mapper;  // unused
     std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;
     std::string spilled_file_ =
-        GetTempPath() + "/sort_spill.arrow" + random_string(128);  // TODO(): get tmp dir
+        GetTempPath() + GenerateUUID() + random_string(128);  // TODO(): get tmp dir
     ARROW_ASSIGN_OR_RAISE(spilled_file_os_,
                           arrow::io::FileOutputStream::Open(spilled_file_, true));
 
@@ -341,6 +351,7 @@ class SortArraysToIndicesKernel::Impl {
   std::vector<bool> nulls_order_;
   bool NaN_check_;
   int col_num_ = 0;
+  std::string local_spill_dir;
 
   class TypedSorterCodeGenImpl {
    public:
@@ -1357,6 +1368,11 @@ class SortOnekeyKernel : public SortArraysToIndicesKernel::Impl {
     return arrow::Status::OK();
   }
 
+  std::string GenerateUUID() {
+    boost::uuids::random_generator generator;
+    return boost::uuids::to_string(generator());
+  }
+
   std::string random_string(size_t length) {
     auto randchar = []() -> char {
       const char charset[] =
@@ -1379,7 +1395,7 @@ class SortOnekeyKernel : public SortArraysToIndicesKernel::Impl {
     arrow::ipc::DictionaryFieldMapper dict_file_mapper;  // unused
     std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;
     std::string spilled_file_ =
-        GetTempPath() + "/sort_spill.arrow" + random_string(128);  // TODO(): get tmp dir
+        GetTempPath() + GenerateUUID() + random_string(128);  // TODO(): get tmp dir
     ARROW_ASSIGN_OR_RAISE(spilled_file_os_,
                           arrow::io::FileOutputStream::Open(spilled_file_, true));
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/window_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/window_kernel.cc
@@ -105,7 +105,7 @@ WindowAggregateFunctionKernel::WindowAggregateFunctionKernel(
  * | 3 |     1 |   |     1 |   3 |          |      3 |
  * | 6 |     0 |                            |      8 |
  */
-arrow::Status WindowAggregateFunctionKernel::Evaluate( ArrayList& in) {
+arrow::Status WindowAggregateFunctionKernel::Evaluate(ArrayList& in) {
   // abstract following code to do common inter-window processing
 
   int32_t max_group_id = 0;
@@ -292,7 +292,7 @@ arrow::Status WindowRankKernel::Make(
   return arrow::Status::OK();
 }
 
-arrow::Status WindowRankKernel::Evaluate( ArrayList& in) {
+arrow::Status WindowRankKernel::Evaluate(ArrayList& in) {
   input_cache_.push_back(in);
   return arrow::Status::OK();
 }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/window_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/window_kernel.cc
@@ -105,7 +105,7 @@ WindowAggregateFunctionKernel::WindowAggregateFunctionKernel(
  * | 3 |     1 |   |     1 |   3 |          |      3 |
  * | 6 |     0 |                            |      8 |
  */
-arrow::Status WindowAggregateFunctionKernel::Evaluate(const ArrayList& in) {
+arrow::Status WindowAggregateFunctionKernel::Evaluate( ArrayList& in) {
   // abstract following code to do common inter-window processing
 
   int32_t max_group_id = 0;
@@ -292,7 +292,7 @@ arrow::Status WindowRankKernel::Make(
   return arrow::Status::OK();
 }
 
-arrow::Status WindowRankKernel::Evaluate(const ArrayList& in) {
+arrow::Status WindowRankKernel::Evaluate( ArrayList& in) {
   input_cache_.push_back(in);
   return arrow::Status::OK();
 }

--- a/native-sql-engine/cpp/src/codegen/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/code_generator.h
@@ -33,7 +33,7 @@ class CodeGenerator {
   virtual arrow::Status getResSchema(std::shared_ptr<arrow::Schema>* out) = 0;
   virtual arrow::Status SetMember(const std::shared_ptr<arrow::RecordBatch>& ms) = 0;
   virtual arrow::Status evaluate(
-      const std::shared_ptr<arrow::RecordBatch>& in,
+       std::shared_ptr<arrow::RecordBatch>& in,
       std::vector<std::shared_ptr<arrow::RecordBatch>>* out) = 0;
   virtual arrow::Status finish(std::vector<std::shared_ptr<arrow::RecordBatch>>* out) = 0;
   virtual std::string GetSignature() { return ""; };

--- a/native-sql-engine/cpp/src/codegen/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/code_generator.h
@@ -33,7 +33,7 @@ class CodeGenerator {
   virtual arrow::Status getResSchema(std::shared_ptr<arrow::Schema>* out) = 0;
   virtual arrow::Status SetMember(const std::shared_ptr<arrow::RecordBatch>& ms) = 0;
   virtual arrow::Status evaluate(
-       std::shared_ptr<arrow::RecordBatch>& in,
+      std::shared_ptr<arrow::RecordBatch>& in,
       std::vector<std::shared_ptr<arrow::RecordBatch>>* out) = 0;
   virtual arrow::Status finish(std::vector<std::shared_ptr<arrow::RecordBatch>>* out) = 0;
   virtual std::string GetSignature() { return ""; };

--- a/native-sql-engine/cpp/src/codegen/compute_ext/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/compute_ext/code_generator.h
@@ -45,7 +45,7 @@ class ComputeExtCodeGenerator : public CodeGenerator {
     return status;
   }
 
-  arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
+  arrow::Status evaluate(std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
     arrow::Status status = arrow::Status::OK();
     return status;

--- a/native-sql-engine/cpp/src/codegen/compute_ext/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/compute_ext/code_generator.h
@@ -45,7 +45,7 @@ class ComputeExtCodeGenerator : public CodeGenerator {
     return status;
   }
 
-  arrow::Status evaluate(const std::shared_ptr<arrow::RecordBatch>& in,
+  arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
     arrow::Status status = arrow::Status::OK();
     return status;

--- a/native-sql-engine/cpp/src/codegen/gandiva/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/gandiva/code_generator.h
@@ -42,7 +42,7 @@ class GandivaCodeGenerator : public CodeGenerator {
   arrow::Status SetMember(const std::shared_ptr<arrow::RecordBatch>& in) {
     return arrow::Status::OK();
   }
-  arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
+  arrow::Status evaluate(std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
     return arrow::Status::OK();
   }

--- a/native-sql-engine/cpp/src/codegen/gandiva/code_generator.h
+++ b/native-sql-engine/cpp/src/codegen/gandiva/code_generator.h
@@ -42,7 +42,7 @@ class GandivaCodeGenerator : public CodeGenerator {
   arrow::Status SetMember(const std::shared_ptr<arrow::RecordBatch>& in) {
     return arrow::Status::OK();
   }
-  arrow::Status evaluate(const std::shared_ptr<arrow::RecordBatch>& in,
+  arrow::Status evaluate( std::shared_ptr<arrow::RecordBatch>& in,
                          std::vector<std::shared_ptr<arrow::RecordBatch>>* out) {
     return arrow::Status::OK();
   }

--- a/native-sql-engine/cpp/src/jni/jni_wrapper.cc
+++ b/native-sql-engine/cpp/src/jni/jni_wrapper.cc
@@ -998,9 +998,8 @@ Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_nativeSpill(
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> FromBytes(
     JNIEnv* env, std::shared_ptr<arrow::Schema> schema, jbyteArray bytes) {
-  ARROW_ASSIGN_OR_RAISE(
-      std::shared_ptr<arrow::RecordBatch> batch,
-      arrow::jniutil::DeserializeUnsafeFromJava(env, schema, bytes))
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::RecordBatch> batch,
+                        arrow::jniutil::DeserializeUnsafeFromJava(env, schema, bytes))
   return batch;
 }
 
@@ -1035,7 +1034,6 @@ Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeEvaluate2(
   }
 
   return record_batch_builder_array;
-
 }
 
 JNIEXPORT jlong JNICALL

--- a/native-sql-engine/cpp/src/jni/jni_wrapper.cc
+++ b/native-sql-engine/cpp/src/jni/jni_wrapper.cc
@@ -21,6 +21,7 @@
 #include <arrow/io/memory.h>
 #include <arrow/ipc/api.h>
 #include <arrow/ipc/dictionary.h>
+#include <arrow/jniutil/jni_util.h>
 #include <arrow/memory_pool.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
@@ -993,6 +994,48 @@ Java_com_intel_oap_vectorized_ShuffleSplitterJniWrapper_nativeSpill(
     return -1L;
   }
   return spilled_size;
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> FromBytes(
+    JNIEnv* env, std::shared_ptr<arrow::Schema> schema, jbyteArray bytes) {
+  ARROW_ASSIGN_OR_RAISE(
+      std::shared_ptr<arrow::RecordBatch> batch,
+      arrow::jniutil::DeserializeUnsafeFromJava(env, schema, bytes))
+  return batch;
+}
+
+JNIEXPORT jobject JNICALL
+Java_com_intel_oap_vectorized_ExpressionEvaluatorJniWrapper_nativeEvaluate2(
+    JNIEnv* env, jobject obj, jlong id, jbyteArray bytes) {
+  arrow::Status status;
+  std::shared_ptr<CodeGenerator> handler = GetCodeGenerator(env, id);
+  std::shared_ptr<arrow::Schema> schema;
+  status = handler->getSchema(&schema);
+
+  auto maybe_batch = FromBytes(env, schema, bytes);
+  auto in = std::move(*maybe_batch);
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> out;
+  status = handler->evaluate(in, &out);
+
+  if (!status.ok()) {
+    std::string error_message =
+        "nativeEvaluate: evaluate failed with error msg " + status.ToString();
+    env->ThrowNew(io_exception_class, error_message.c_str());
+  }
+
+  std::shared_ptr<arrow::Schema> res_schema;
+  status = handler->getResSchema(&res_schema);
+  jobjectArray record_batch_builder_array =
+      env->NewObjectArray(out.size(), arrow_record_batch_builder_class, nullptr);
+  int i = 0;
+  for (auto record_batch : out) {
+    jobject record_batch_builder = MakeRecordBatchBuilder(env, res_schema, record_batch);
+    env->SetObjectArrayElement(record_batch_builder_array, i++, record_batch_builder);
+  }
+
+  return record_batch_builder_array;
+
 }
 
 JNIEXPORT jlong JNICALL

--- a/native-sql-engine/cpp/src/tests/arrow_compute_test_join_wocg.cc
+++ b/native-sql-engine/cpp/src/tests/arrow_compute_test_join_wocg.cc
@@ -2398,6 +2398,8 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestStringInnerJoinType2LoadHashRelation) {
   ////////////////////// evaluate //////////////////////
   for (auto batch : table_0) {
     ASSERT_NOT_OK(expr_build_pre->evaluate(batch, &dummy_result_batches));
+  }
+  for (auto batch : table_0) {
     ASSERT_NOT_OK(expr_build->evaluate(batch, &dummy_result_batches));
   }
   std::shared_ptr<ResultIteratorBase> build_result_iterator_base_pre;

--- a/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
@@ -653,7 +653,7 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
     ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
     sort_expr->Spill(100, false, &size);
     if (firstspill) {
-      EXPECT_TRUE(gap == size);
+      EXPECT_TRUE(gap >= size);
     } else {
       EXPECT_TRUE(0 == size);
     }
@@ -662,6 +662,7 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
     ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
     result_iter++;
   }
+  unsetenv("NATIVESQL_BATCH_SIZE");
 }
 
 TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAsc) {

--- a/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
@@ -607,8 +607,7 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
   //////////////////////////////////////
   std::shared_ptr<arrow::RecordBatch> expected_result;
   std::vector<std::string> expected_result_string1 = {
-      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9]",
-      "[34, 67, 2, 3, 4, 5, 7, 8, 9, 10]"};
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9]", "[34, 67, 2, 3, 4, 5, 7, 8, 9, 10]"};
   std::vector<std::string> expected_result_string2 = {
       "[10, 11, 13, 15, 17, 18, 19, 21, "
       "22, 23]",
@@ -619,9 +618,8 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
       "32, 33, 35, 37, 41, 42, 43, 50, 52]",
       "["
       "31, 33, 34, 36, 38, 42, 43, 44, 51, null]"};
-        std::vector<std::string> expected_result_string4 = {
-      "[59, 64, NaN, NaN, NaN]",
-      "[60, 65, 21, null, 13]"};
+  std::vector<std::string> expected_result_string4 = {"[59, 64, NaN, NaN, NaN]",
+                                                      "[60, 65, 21, null, 13]"};
   std::vector<std::shared_ptr<arrow::RecordBatch>> result_batch_list;
   MakeInputBatch(expected_result_string1, sch, &expected_result);
   result_batch_list.push_back(std::move(expected_result));
@@ -655,9 +653,9 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
     ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
     sort_expr->Spill(100, false, &size);
     if (firstspill) {
-        EXPECT_TRUE(gap == size);
+      EXPECT_TRUE(gap == size);
     } else {
-        EXPECT_TRUE(0 == size);
+      EXPECT_TRUE(0 == size);
     }
     firstspill = false;
     expected_result = *result_iter;

--- a/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
@@ -652,11 +652,9 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
   while (sort_result_iterator->HasNext()) {
     ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
     sort_expr->Spill(100, false, &size);
-    if (firstspill) {
-      EXPECT_TRUE(gap >= size);
-    } else {
-      EXPECT_TRUE(0 == size);
-    }
+
+      EXPECT_TRUE(size >= gap);
+
     firstspill = false;
     expected_result = *result_iter;
     ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));

--- a/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
@@ -539,6 +539,101 @@ TEST(TestArrowComputeSort, SortTestInplaceDesc) {
     ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
   }
 }
+TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction("key_function", {arg_0}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction("key_field", {arg_0}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {TreeExprBuilder::MakeLiteral(false)}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices",
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
+  auto n_sort =
+      TreeExprBuilder::MakeFunction("standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  arrow::compute::ExecContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types,
+                                    &sort_expr, true));
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[10, NaN, 4, 50, 52, 32, 11]",
+                                                "[11, 13, 5, 51, null, 33, 12]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(std::move(input_batch));
+
+  std::vector<std::string> input_data_string_2 = {"[1, NaN, 43, 42, 6, null, 2]",
+                                                  "[2, null, 44, 43, 7, 34, 3]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(std::move(input_batch));
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 15, 7, 9, 19, 33]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(std::move(input_batch));
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, NaN, 35, 30]",
+                                                  "[24, 18, 42, 19, 21, 36, 31]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(std::move(input_batch));
+
+  std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(std::move(input_batch));
+
+  ////////////////////////////////// calculation
+  //////////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 13, 15, 17, 18, 19, 21, "
+      "22, 23, 30, "
+      "32, 33, 35, 37, 41, 42, 43, 50, 52, 59, 64, NaN, NaN, NaN]",
+      "[34, 67, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 14, 16, 18, 19, 20, 22, "
+      "23, 24, "
+      "31, 33, 34, 36, 38, 42, 43, 44, 51, null, 60, 65, 21, null, 13]"};
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto& batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  int64_t size;
+  sort_expr->Spill(100, false, &size);
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
 
 TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAsc) {
   ////////////////////// prepare expr_vector ///////////////////////

--- a/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/native-sql-engine/cpp/src/tests/arrow_compute_test_sort.cc
@@ -653,7 +653,7 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAscWithSpill) {
     ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
     sort_expr->Spill(100, false, &size);
 
-      EXPECT_TRUE(size >= gap);
+    EXPECT_TRUE(size >= gap);
 
     firstspill = false;
     expected_result = *result_iter;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch add spill support for sort. 

- The Spill() API of Sort is connected to the TaskMemoryManager of Spark. If under lower memory, Spark will try toissue Spill on Sort. 
- On Spill() is called, executor will try to pick one partiton(one task) then try to write the sort content(keys + payloads) to disks, then release the memory for these consents. For following outputing, sort will first load the spill contents into memory then continue to output the results.
- Please note the Spill will be only called from the following operators of Sort, like SortMergeJoin - this makes spill happens only on sort results outputting phase.
- Currently the spill files will be written into each yarn container, this should be improved to use Spark's blockmanager.

## How was this patch tested?
locally verified

