### PR TITLE
[NSE-382]Fix Hadoop version issue

### DIFF
--- a/arrow-data-source/pom.xml
+++ b/arrow-data-source/pom.xml
@@ -50,6 +50,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/native-sql-engine/core/pom.xml
+++ b/native-sql-engine/core/pom.xml
@@ -255,6 +255,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,88 @@
     </license>
   </licenses>
 
+  <modules>
+    <module>arrow-data-source</module>
+    <module>native-sql-engine/core</module>
+    <module>shims</module>
+  </modules>
+
+  <profiles>
+    <profile>
+      <id>spark</id>
+      <activation>
+          <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+          <spark.version>${spark311.version}</spark.version>
+      </properties>
+    </profile>
+    <profile>
+        <id>spark-3.1.1</id>
+        <properties>
+            <spark.version>${spark311.version}</spark.version>
+        </properties>
+    </profile>
+    <profile>
+      <id>hadoop-2.7.4</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <hadoop.version>2.7.4</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-3.2</id>
+      <properties>
+        <hadoop.version>3.2.0</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>incremental-scala-compiler</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <scala.recompile.mode>incremental</scala.recompile.mode>
+      </properties>
+    </profile>
+    <profile>
+      <id>full-scala-compiler</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <scala.recompile.mode>all</scala.recompile.mode>
+      </properties>
+    </profile>
+    <profile>
+      <id>arrow-netty</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <arrow-memory.artifact>arrow-memory-netty</arrow-memory.artifact>
+      </properties>
+    </profile>
+    <profile>
+      <id>arrow-unsafe</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
+      </properties>
+    </profile>
+  </profiles>
+
   <properties>
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.1.1</spark.version>
     <arrow.version>4.0.0</arrow.version>
     <arrow-memory.artifact>arrow-memory-netty</arrow-memory.artifact>
-    <hadoop.version>2.7.4</hadoop.version>
+    <hadoop.version>${hadoop.version}</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <arrow.script.dir>${project.basedir}/script</arrow.script.dir>
@@ -49,12 +124,6 @@
     <project.name.prefix>OAP Project Spark Columnar Plugin</project.name.prefix>
     <spark311.version>3.1.1</spark311.version>
   </properties>
-
-  <modules>
-    <module>arrow-data-source</module>
-    <module>native-sql-engine/core</module>
-    <module>shims</module>
-  </modules>
 
   <dependencyManagement>
     <dependencies>
@@ -189,63 +258,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <profiles>
-    <profile>
-      <id>spark</id>
-      <activation>
-          <activeByDefault>true</activeByDefault>
-      </activation>  
-      <properties>
-          <spark.version>${spark311.version}</spark.version>
-      </properties>
-    </profile>
-    <profile>
-        <id>spark-3.1.1</id>
-        <properties>
-            <spark.version>${spark311.version}</spark.version>
-        </properties>
-    </profile>
-    <profile>
-      <id>hadoop-3.2</id>
-      <properties>
-        <hadoop.version>3.2.0</hadoop.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>incremental-scala-compiler</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <scala.recompile.mode>incremental</scala.recompile.mode>
-      </properties>
-    </profile>
-    <profile>
-      <id>full-scala-compiler</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <scala.recompile.mode>all</scala.recompile.mode>
-      </properties>
-    </profile>
-    <profile>
-      <id>arrow-netty</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <arrow-memory.artifact>arrow-memory-netty</arrow-memory.artifact>
-      </properties>
-    </profile>
-    <profile>
-      <id>arrow-unsafe</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,9 @@
     <profile>
       <id>hadoop-2.7.4</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop.version</name>
+        </property>
       </activation>
       <properties>
         <hadoop.version>2.7.4</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,16 +92,8 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
+        <id>arrow-netty</id>
         <arrow-memory.artifact>arrow-memory-netty</arrow-memory.artifact>
-      </properties>
-    </profile>
-    <profile>
-      <id>arrow-unsafe</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
       </properties>
     </profile>
   </profiles>
@@ -111,7 +103,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.1.1</spark.version>
     <arrow.version>4.0.0</arrow.version>
-    <arrow-memory.artifact>arrow-memory-netty</arrow-memory.artifact>
+    <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
     <hadoop.version>${hadoop.version}</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -259,5 +251,30 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.6.3</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add hadoop.version for hadoop client in arrow-data-source and native-sql-engine
2. Add profile setting for hadoop version control, default use hadoop 2.7.4
3. Fixing one issue for the variable: hadoop.version does not apply to hadoop-client library in compiler phase before.
4. Move the order of profile section to higher for better reading

## How was this patch tested?

Tested in local server.

