### PR TITLE
[NSE-382]Support GCP Dataproc 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
       </properties>
     </profile>
     <profile>
+      <id>dataproc-2.0</id>
+      <properties>
+        <hadoop.version>3.2.2</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
       <id>incremental-scala-compiler</id>
       <activation>
         <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Hadoop 3.2.2 for GCP Dataproc 2.0 support
Close #382 

## How was this patch tested?

The jar has been tested on GCP Dataproc 2.0 image and pass all TPC-DS queries in SF2.



