### PR TITLE
[NSE-368]Update emr-6.3.0 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
       </properties>
     </profile>
     <profile>
+      <id>emr-6.3.0</id>
+      <properties>
+        <hadoop.version>3.2.1</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
       <id>incremental-scala-compiler</id>
       <activation>
         <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add AWS EMR 6.3.0 Support with Hadoop 3.2.1.
Close #368 

## How was this patch tested?

The jar has been tested in AWS EMR 6.3.0 and can pass all 99 TPC-DS queries(turn off adaptive).
