### PR TITLE
[NSE-421]Disable the wholestagecodegen feature for the ArrowColumnarToRow operator

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ArrowColumnarToRowExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ArrowColumnarToRowExec.scala
@@ -34,6 +34,8 @@ import scala.concurrent.duration._
 class ArrowColumnarToRowExec(child: SparkPlan) extends ColumnarToRowExec(child = child) {
   override def nodeName: String = "ArrowColumnarToRow"
 
+  override def supportCodegen: Boolean = false
+
   buildCheck()
 
   def buildCheck(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR disable the wholestagecodegen feature in ArrowColumnarToRow operator and will enable later.

[#421 ](https://github.com/oap-project/gazelle_plugin/issues/421)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

