### PR TITLE
[NSE-417] fix sort spill on inplsace sort

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/expr_visitor_impl.h
@@ -510,7 +510,6 @@ class SortArraysToIndicesVisitorImpl : public ExprVisitorImpl {
   }
 
   arrow::Status Spill(int64_t size, int64_t* spilled_size) override {
-    std::cout << "target size: " << size << std::endl;
     RETURN_NOT_OK(kernel_->Spill(size, spilled_size));
 
     if (*spilled_size != 0) {

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -839,8 +839,6 @@ extern "C" void MakeCodeGen(arrow::compute::ExecContext* ctx,
       if (!spillablecachestore_) {
         spillablecachestore_ = std::make_shared<SpillableCacheStore>(cached_in_, schema_);
       }
-      std::cout << "call on: " << spillablecachestore_->GetSpillDir() << "|"
-                << is_spilled_ << "\n";
       if (is_spilled_) {
         // TODO: this should be fixed when spill in sorting
         *spilled_size = 0;
@@ -981,6 +979,13 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
     }
 
     items_total_ += in[0]->length();
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Spill(int64_t size, int64_t* spilled_size) {
+    //inplace sort does not support spill
+    *spilled_size = 0;
+
     return arrow::Status::OK();
   }
 

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -983,7 +983,7 @@ class SortInplaceKernel : public SortArraysToIndicesKernel::Impl {
   }
 
   arrow::Status Spill(int64_t size, int64_t* spilled_size) {
-    //inplace sort does not support spill
+    // inplace sort does not support spill
     *spilled_size = 0;
 
     return arrow::Status::OK();


### PR DESCRIPTION

## What changes were proposed in this pull request?

this patch fix spill on inplace sort, which is not supported yet
also cleaned up on the debug logs.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?

locally verified
