### PR TITLE
[NSE-254] remove arrow-data-source-common from jar with dependency

### DIFF
--- a/native-sql-engine/core/pom.xml
+++ b/native-sql-engine/core/pom.xml
@@ -133,6 +133,7 @@
       <artifactId>spark-arrow-datasource-common</artifactId>
       <groupId>com.intel.oap</groupId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>


### PR DESCRIPTION

## What changes were proposed in this pull request?

native sql engine is bundled with arrow data source now so
it should be safe to assume those dataset related class will
be 'pre-loaded'

with this fix the jar size is ~97MB(was ~147MB) on my local env

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

locally verified
