### PR TITLE
[NSE-460] fix decimal partial sum in 1.2 branch

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/actions_impl.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/actions_impl.cc
@@ -2093,7 +2093,7 @@ class SumActionPartial<DataType, CType, ResDataType, ResCType,
         builder_isempty_->Append(true);
       } else {
         builder_->AppendNull();
-        builder_isempty_->AppendNull();
+        builder_isempty_->Append(false);
       }
     }
     RETURN_NOT_OK(builder_->Finish(&arr_out));
@@ -2116,7 +2116,7 @@ class SumActionPartial<DataType, CType, ResDataType, ResCType,
         builder_isempty_->Append(true);
       } else {
         builder_->AppendNull();
-        builder_isempty_->AppendNull();
+        builder_isempty_->Append(false);
       }
     }
     RETURN_NOT_OK(builder_->Finish(&arr_out));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix missing is_empty value
cherry-picked from https://github.com/oap-project/gazelle_plugin/pull/447/commits/bff3bf8779e0f5552f9d80260c9ad94d52fa5445
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

locally verified

