### PR TITLE
[NSE-484] Make AVG an experimental feature of ColumnarWindow

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -66,6 +66,9 @@ class ColumnarPluginConfig(conf: SQLConf) extends Logging {
   // enable or disable columnar window  
   val enableColumnarWindow: Boolean =
     conf.getConfString("spark.oap.sql.columnar.window", "true").toBoolean && enableCpu
+
+  val enableColumnarWindowExperimentalFeatures: Boolean =
+    conf.getConfString("spark.oap.sql.columnar.window.experimental", "false").toBoolean && enableCpu
   
   // enable or disable columnar shuffledhashjoin
   val enableColumnarShuffledHashJoin: Boolean =
@@ -180,7 +183,7 @@ object ColumnarPluginConfig {
   /**
    * @deprecated We should avoid caching this value in entire JVM. us
    */
-  @Deprecated
+  @deprecated
   def getConf: ColumnarPluginConfig = synchronized {
     if (ins == null) {
       ins = getSessionConf

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarWindowExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarWindowExec.scala
@@ -128,6 +128,16 @@ case class ColumnarWindowExec(windowExpression: Seq[NamedExpression],
     // leave it empty for now
   }
 
+  def requireExperimental(describe: String): Unit = {
+    if (!ColumnarPluginConfig.getSessionConf.enableColumnarWindowExperimentalFeatures) {
+      throw new UnsupportedOperationException(
+        s"${describe} is experimental feature of columnar window and not enabled here. To " +
+            s"enable try setting spark.oap.sql.columnar.window.experimental = true in Spark " +
+            s"configuration."
+      )
+    }
+  }
+
   def validateWindowFunctions(): Seq[(String, Expression)] = {
     val windowFunctions = windowExpression
         .map(e => e.asInstanceOf[Alias])
@@ -150,6 +160,7 @@ case class ColumnarWindowExec(windowExpression: Seq[NamedExpression],
                 checkAggFunctionSpec(expr.windowSpec)
                 "sum"
               case _: Average =>
+                requireExperimental("Window AVG")
                 checkAggFunctionSpec(expr.windowSpec)
                 "avg"
               case _: Min =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Window AVG will be an experimental feature. Setting `spark.oap.sql.columnar.window.experimental=true` to enable

