### PR TITLE
[NSE-475] restore coalescebatches operator before window

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarWindowExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarWindowExec.scala
@@ -504,7 +504,7 @@ object ColumnarWindowExec extends Logging {
   object ColumnarWindowOptimizations extends RuleExecutor[SparkPlan] {
     override protected def batches: Seq[ColumnarWindowOptimizations.Batch] =
       Batch("Remove Sort", FixedPoint(10), RemoveSort) ::
-          Batch("Remove Coalesce Batches", FixedPoint(10), RemoveCoalesceBatches) ::
+//          Batch("Remove Coalesce Batches", FixedPoint(10), RemoveCoalesceBatches) ::
 //          Batch("Cast Mutable Types", Once, CastMutableTypes) ::
           Batch("Add Projections", FixedPoint(1), AddProjectionsAroundWindow) ::
           Batch("Validate", Once, Validate) ::

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarWindowExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarWindowExec.scala
@@ -504,8 +504,6 @@ object ColumnarWindowExec extends Logging {
   object ColumnarWindowOptimizations extends RuleExecutor[SparkPlan] {
     override protected def batches: Seq[ColumnarWindowOptimizations.Batch] =
       Batch("Remove Sort", FixedPoint(10), RemoveSort) ::
-//          Batch("Remove Coalesce Batches", FixedPoint(10), RemoveCoalesceBatches) ::
-//          Batch("Cast Mutable Types", Once, CastMutableTypes) ::
           Batch("Add Projections", FixedPoint(1), AddProjectionsAroundWindow) ::
           Batch("Validate", Once, Validate) ::
           Nil


### PR DESCRIPTION


## What changes were proposed in this pull request?

This patch restore the coalescebatches before window so the "empty partitions" were removed
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?

locally verified

