### PR TITLE
[NSE-532] Fix the failed UTs in ArrowEvalPythonExecSuite when enable ArrowColumnarToRow

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ArrowColumnarToRowExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ArrowColumnarToRowExec.scala
@@ -107,6 +107,7 @@ class ArrowColumnarToRowExec(child: SparkPlan) extends ColumnarToRowExec(child =
           recordBatch.getBuffersLayout().asScala.foreach { bufLayout =>
             bufSizes += bufLayout.getSize()
           }
+          ConverterUtils.releaseArrowRecordBatch(recordBatch)
 
           val fields = new ListBuffer[Field]()
           (0 until batch.numCols).foreach { idx =>

--- a/native-sql-engine/core/src/test/scala/com/intel/oap/execution/ArrowColumnarToRowExecSuite.scala
+++ b/native-sql-engine/core/src/test/scala/com/intel/oap/execution/ArrowColumnarToRowExecSuite.scala
@@ -326,6 +326,7 @@ object ArrowColumnarToRowExecSuite {
     recordBatch.getBuffersLayout().asScala.foreach { bufLayout =>
       bufSizes += bufLayout.getSize()
     }
+    ConverterUtils.releaseArrowRecordBatch(recordBatch)
 
     (0 until batch.numCols).foreach { idx =>
       val column = batch.column(idx).asInstanceOf[ArrowWritableColumnVector]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix releasing recordbatch in columntorow


## How was this patch tested?

Jenkins passed
