### PR TITLE
[NSE-602] don't enable columnar shuffle on unsupported data types

### DIFF
--- a/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -97,11 +97,11 @@ case class ColumnarShuffleExchangeExec(
     // check input datatype
     for (attr <- child.output) {
       try {
-        ConverterUtils.createArrowField(attr)
+        ConverterUtils.checkIfTypeSupported(attr.dataType)
       } catch {
         case e: UnsupportedOperationException =>
           throw new UnsupportedOperationException(
-            s"${attr.dataType} is not supported in ColumnarShuffleExchange")
+            s"${attr.dataType} is not supported in ColumnarShuffledHashJoinExec.")
       }
     }
   }

--- a/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -101,7 +101,7 @@ case class ColumnarShuffleExchangeExec(
       } catch {
         case e: UnsupportedOperationException =>
           throw new UnsupportedOperationException(
-            s"${attr.dataType} is not supported in ColumnarShuffledHashJoinExec.")
+            s"${attr.dataType} is not supported in ColumnarShuffledExchangeExec.")
       }
     }
   }


### PR DESCRIPTION


## What changes were proposed in this pull request?

This patch disabled colummnar shuffle on array/map/struct

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?
passing jenkins

