### PR TITLE
[NSE-576] Support from_unixtime expression in the case that 'yyyyMMdd' format is required

### DIFF
--- a/arrow-data-source/script/build_arrow.sh
+++ b/arrow-data-source/script/build_arrow.sh
@@ -62,7 +62,7 @@ echo "ARROW_SOURCE_DIR=${ARROW_SOURCE_DIR}"
 echo "ARROW_INSTALL_DIR=${ARROW_INSTALL_DIR}"
 mkdir -p $ARROW_SOURCE_DIR
 mkdir -p $ARROW_INSTALL_DIR
-git clone https://github.com/philo-he/arrow.git  --branch from_unixtime $ARROW_SOURCE_DIR
+git clone https://github.com/oap-project/arrow.git  --branch arrow-4.0.0-oap $ARROW_SOURCE_DIR
 pushd $ARROW_SOURCE_DIR
 
 cmake ./cpp \

--- a/arrow-data-source/script/build_arrow.sh
+++ b/arrow-data-source/script/build_arrow.sh
@@ -62,7 +62,7 @@ echo "ARROW_SOURCE_DIR=${ARROW_SOURCE_DIR}"
 echo "ARROW_INSTALL_DIR=${ARROW_INSTALL_DIR}"
 mkdir -p $ARROW_SOURCE_DIR
 mkdir -p $ARROW_INSTALL_DIR
-git clone https://github.com/oap-project/arrow.git  --branch arrow-4.0.0-oap $ARROW_SOURCE_DIR
+git clone https://github.com/philo-he/arrow.git  --branch from_unixtime $ARROW_SOURCE_DIR
 pushd $ARROW_SOURCE_DIR
 
 cmake ./cpp \

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
@@ -510,7 +510,7 @@ object ColumnarDateTimeExpressions {
         right match {
           case literal: ColumnarLiteral =>
             val format = literal.value.toString
-            if (format.length != 10) {
+            if (!format.equals("yyyy-MM-dd") && !format.equals("yyyyMMdd")) {
               throw new UnsupportedOperationException(
                 s"$format is not supported in ColumnarFromUnixTime.")
             }
@@ -534,9 +534,19 @@ object ColumnarDateTimeExpressions {
         throw new UnsupportedOperationException(
           s"${left.dataType} is not supported in ColumnarFromUnixTime.")
       }
+      var formatLength = 0L
+      right match {
+        case literal: ColumnarLiteral =>
+          val format = literal.value.toString
+          if (format.equals("yyyy-MM-dd")) {
+            formatLength = 10L
+          } else if (format.equals("yyyyMMdd")) {
+            formatLength = 8L
+          }
+      }
       val dateNode = TreeBuilder.makeFunction(
-        "castVARCHAR", Lists.newArrayList(date32LeftNode, TreeBuilder.makeLiteral(java.lang.Long.valueOf(10L))), outType)
-
+        "castVARCHAR", Lists.newArrayList(date32LeftNode,
+          TreeBuilder.makeLiteral(java.lang.Long.valueOf(formatLength))), outType)
       (dateNode, outType)
     }
   }


### PR DESCRIPTION
This patch depends on https://github.com/oap-project/arrow/pull/56.