### PR TITLE
[NSE-609] Complete to_date expression support

### DIFF
--- a/arrow-data-source/script/build_arrow.sh
+++ b/arrow-data-source/script/build_arrow.sh
@@ -62,7 +62,7 @@ echo "ARROW_SOURCE_DIR=${ARROW_SOURCE_DIR}"
 echo "ARROW_INSTALL_DIR=${ARROW_INSTALL_DIR}"
 mkdir -p $ARROW_SOURCE_DIR
 mkdir -p $ARROW_INSTALL_DIR
-git clone https://github.com/philo-he/arrow.git --branch check_input $ARROW_SOURCE_DIR
+git clone https://github.com/oap-project/arrow.git  --branch arrow-4.0.0-oap $ARROW_SOURCE_DIR
 pushd $ARROW_SOURCE_DIR
 
 cmake ./cpp \

--- a/arrow-data-source/script/build_arrow.sh
+++ b/arrow-data-source/script/build_arrow.sh
@@ -62,7 +62,7 @@ echo "ARROW_SOURCE_DIR=${ARROW_SOURCE_DIR}"
 echo "ARROW_INSTALL_DIR=${ARROW_INSTALL_DIR}"
 mkdir -p $ARROW_SOURCE_DIR
 mkdir -p $ARROW_INSTALL_DIR
-git clone https://github.com/oap-project/arrow.git  --branch arrow-4.0.0-oap $ARROW_SOURCE_DIR
+git clone https://github.com/philo-he/arrow.git --branch check_input $ARROW_SOURCE_DIR
 pushd $ARROW_SOURCE_DIR
 
 cmake ./cpp \

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarBinaryExpression.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarBinaryExpression.scala
@@ -30,12 +30,14 @@ import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeID
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
+
 import scala.collection.mutable.ListBuffer
 
 import com.intel.oap.expression.ColumnarDateTimeExpressions.ColumnarDateDiff
 import com.intel.oap.expression.ColumnarDateTimeExpressions.ColumnarDateSub
 import com.intel.oap.expression.ColumnarDateTimeExpressions.ColumnarUnixTimestamp
 import com.intel.oap.expression.ColumnarDateTimeExpressions.ColumnarFromUnixTime
+import com.intel.oap.expression.ColumnarDateTimeExpressions.ColumnarGetTimestamp
 
 /**
  * A version of add that supports columnar processing for longs.
@@ -104,6 +106,10 @@ object ColumnarBinaryExpression {
         new ColumnarDateDiff(left, right)
       case a: UnixTimestamp =>
         new ColumnarUnixTimestamp(left, right)
+      // To match GetTimestamp (a private class).
+      case _ if (original.isInstanceOf[ToTimestamp] && original.dataType == TimestampType) =>
+        // Convert a string to Timestamp. Default timezone is used.
+        new ColumnarGetTimestamp(left, right, None)
       case a: FromUnixTime =>
         new ColumnarFromUnixTime(left, right)
       case d: DateSub =>

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
@@ -518,6 +518,13 @@ object ColumnarDateTimeExpressions {
     buildCheck()
 
     def buildCheck(): Unit = {
+      val parserPolicy = SQLConf.get.getConf(SQLConf.LEGACY_TIME_PARSER_POLICY);
+      // TODO: support "exception" time parser policy.
+      if (!parserPolicy.equalsIgnoreCase("corrected")) {
+        throw new UnsupportedOperationException(
+          s"$parserPolicy is NOT a supported time parser policy");
+      }
+      
       val supportedTypes = List(StringType)
       if (supportedTypes.indexOf(left.dataType) == -1) {
         throw new UnsupportedOperationException(

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
@@ -551,13 +551,8 @@ object ColumnarDateTimeExpressions {
             val funcNode = TreeBuilder.makeFunction("castTIMESTAMP_withCarrying",
               Lists.newArrayList(leftNode), intermediateType)
             ConverterUtils.convertTimestampToMicro(funcNode, intermediateType)
-          } else if (format.equals("yyyyMMdd")) {
-            // TODO: introduce a new gandiva function.
-            val funcNode = TreeBuilder.makeFunction("castTIMESTAMP_without_hyphen",
-              Lists.newArrayList(leftNode), intermediateType)
-            ConverterUtils.convertTimestampToMicro(funcNode, intermediateType)
-            // TODO: add other format support.
           } else {
+            // TODO: add other format support.
             throw new UnsupportedOperationException(
               s"$format is not supported in ColumnarUnixTimestamp.")
           }

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
@@ -548,7 +548,7 @@ object ColumnarDateTimeExpressions {
         case literal: ColumnarLiteral =>
           val format = literal.value.toString
           if (format.equals("yyyy-MM-dd")) {
-            val funcNode = TreeBuilder.makeFunction("castTIMESTAMP_withCarrying",
+            val funcNode = TreeBuilder.makeFunction("castTIMESTAMP_with_validation_check",
               Lists.newArrayList(leftNode), intermediateType)
             ConverterUtils.convertTimestampToMicro(funcNode, intermediateType)
           } else {


### PR DESCRIPTION
In spark, to_date(string [, fmt]) is used to parse a string to DateType according to given format or default format.

There is no dedicated expression for to_date in vanilla spark. 
1) If fmt is not given, spark will cast string to DateType by corresponding cast expression, which is already supported in gazelle.
2) If fmt is given, spark will firstly use GetTimestamp expression to get timestamp (TimestampType) from the string, then cast the TimestampType to DateType. For this case, we proposed this patch to support it. Currently, only "yyyy-MM-dd" format is supported, otherwise, it will fallback to vanilla spark's execution path.