### PR TITLE
[NSE-601] Fix an issue in the case of group by coalesce

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -169,7 +169,7 @@ case class ColumnarSortExec(
   def getCodeGenSignature =
     if (sortOrder.exists(expr =>
         !expr.child.isInstanceOf[Literal] &&
-        bindReference(ConverterUtils.getAttrFromExpr(expr.child), child.output, true)
+        bindReference(ConverterUtils.getAttrFromExpr(expr.child, true), child.output, true)
         .isInstanceOf[BoundReference])) {
       ColumnarSorter.prebuild(
         sortOrder,

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -70,12 +70,12 @@ class ColumnarSorter(
   val resultSchema: StructType = StructType(
     outputAttributes
       .map(expr => {
-        val attr = ConverterUtils.getAttrFromExpr(expr)
+        val attr = ConverterUtils.getAttrFromExpr(expr, true)
         StructField(s"${attr.name.toLowerCase()}", attr.dataType, nullable = true)
       })
       .toArray)
   val outputFieldList: List[Field] = outputAttributes.toList.map(expr => {
-    val attr = ConverterUtils.getAttrFromExpr(expr)
+    val attr = ConverterUtils.getAttrFromExpr(expr, true)
     Field.nullable(s"${attr.name.toLowerCase()}#${attr.exprId.id}",
         CodeGeneration.getResultType(attr.dataType))
   })
@@ -179,12 +179,12 @@ object ColumnarSorter extends Logging {
 
   def checkIfKeyFound(sortOrder: Seq[SortOrder], outputAttributes: Seq[Attribute]): Unit = {
     val outputFieldList: List[Field] = outputAttributes.toList.map(expr => {
-      val attr = ConverterUtils.getAttrFromExpr(expr)
+      val attr = ConverterUtils.getAttrFromExpr(expr, true)
       Field.nullable(s"${attr.name.toLowerCase()}#${attr.exprId.id}",
         CodeGeneration.getResultType(attr.dataType))
     })
     sortOrder.toList.foreach(sort => {
-      val attr = ConverterUtils.getAttrFromExpr(sort.child)
+      val attr = ConverterUtils.getAttrFromExpr(sort.child, true)
       val field = Field.nullable(s"${attr.name.toLowerCase()}#${attr.exprId.id}",
         CodeGeneration.getResultType(attr.dataType))
       if (outputFieldList.indexOf(field) == -1) {
@@ -200,7 +200,7 @@ object ColumnarSorter extends Logging {
       outputAttributes: Seq[Attribute]): TreeNode = {
     checkIfKeyFound(sortOrder, outputAttributes)
     val keyFieldList: List[Field] = sortOrder.toList.map(sort => {
-      val attr = ConverterUtils.getAttrFromExpr(sort.child)
+      val attr = ConverterUtils.getAttrFromExpr(sort.child, true)
       Field.nullable(s"${attr.name.toLowerCase()}#${attr.exprId.id}",
         CodeGeneration.getResultType(attr.dataType))
     })
@@ -237,7 +237,7 @@ object ColumnarSorter extends Logging {
     val codegen = GazellePluginConfig.getConf.enableColumnarCodegenSort
     /////////////// Prepare ColumnarSorter //////////////
     val keyFieldList: List[Field] = sortOrder.toList.map(sort => {
-      val attr = ConverterUtils.getAttrFromExpr(sort.child)
+      val attr = ConverterUtils.getAttrFromExpr(sort.child, true)
       Field.nullable(s"${attr.name.toLowerCase()}#${attr.exprId.id}",
         CodeGeneration.getResultType(attr.dataType))
     })
@@ -345,7 +345,7 @@ object ColumnarSorter extends Logging {
       outputAttributes: Seq[Attribute],
       _sparkConf: SparkConf): (ExpressionTree, Schema) = {
     val outputFieldList: List[Field] = outputAttributes.toList.map(expr => {
-      val attr = ConverterUtils.getAttrFromExpr(expr)
+      val attr = ConverterUtils.getAttrFromExpr(expr, true)
       Field.nullable(s"${attr.name.toLowerCase()}#${attr.exprId.id}",
           CodeGeneration.getResultType(attr.dataType))
     })

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -324,15 +324,14 @@ object ConverterUtils extends Logging {
       case a: AttributeReference =>
         a
       case a: Alias =>
-        if (skipAlias && a.child.isInstanceOf[AttributeReference]) {
-          getAttrFromExpr(a.child)
-        } else {
-          // FIXME(): special case
-          if (a.child.isInstanceOf[Coalesce]) {
+        if (skipAlias) {
+          if (a.child.isInstanceOf[AttributeReference] || a.child.isInstanceOf[Coalesce]) {
             getAttrFromExpr(a.child)
           } else {
             a.toAttribute.asInstanceOf[AttributeReference]
           }
+        } else {
+            a.toAttribute.asInstanceOf[AttributeReference]
         }
       case a: KnownFloatingPointNormalized =>
         logInfo(s"$a")


### PR DESCRIPTION
This is a regression issue caused by the fixing in #601.
For columnar sort, we set `skipAlias` to `true` in all pieces of code that ConverterUtils.getAttrFromExpr() is involved.