### PR TITLE
[NSE-651]Use Hadoop 3.2 as default hadoop.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,17 @@
     </profile>
     <profile>
       <id>hadoop-2.7.4</id>
-      <activation>
-        <property>
-          <name>!hadoop.version</name>
-        </property>
-      </activation>
       <properties>
         <hadoop.version>2.7.4</hadoop.version>
       </properties>
     </profile>
     <profile>
       <id>hadoop-3.2</id>
+      <activation>
+        <property>
+          <name>!hadoop.version</name>
+        </property>
+      </activation>
       <properties>
         <hadoop.version>3.2.0</hadoop.version>
       </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the default hadoop version to 3.2 if not set during compile

## How was this patch tested?
Pass test in local develop server.

