### PR TITLE
[NSE-740] Catch out_of_range exception in casting string to numeric types in wscg

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
@@ -683,6 +683,8 @@ arrow::Status ExpressionCodegenVisitor::Visit(const gandiva::FunctionNode& node)
                << ");" << std::endl;
     prepare_ss << "} catch (std::invalid_argument) {" << std::endl;
     prepare_ss << validity << " = false;" << std::endl;
+    prepare_ss << "} catch (std::out_of_range)" << std::endl;
+    prepare_ss << validity << " = false;" << std::endl;
     prepare_ss << "}" << std::endl;
     prepare_ss << "}" << std::endl;
 


### PR DESCRIPTION
It seems runtime_error is out of the scope of logical error in the casting. Let me double think whether that exception should be caught also.