### PR TITLE
[NSE-766] Support running with JDK11

### DIFF
--- a/arrow-data-source/common/pom.xml
+++ b/arrow-data-source/common/pom.xml
@@ -43,6 +43,13 @@
       </exclusions>
       <scope>compile</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.sun.xml.messaging.saaj/saaj-impl -->
+    <dependency>
+      <groupId>com.sun.xml.messaging.saaj</groupId>
+      <artifactId>saaj-impl</artifactId>
+      <version>1.5.3</version>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>

--- a/arrow-data-source/common/src/main/scala/org/apache/spark/sql/execution/datasources/v2/arrow/SparkMemoryUtils.scala
+++ b/arrow-data-source/common/src/main/scala/org/apache/spark/sql/execution/datasources/v2/arrow/SparkMemoryUtils.scala
@@ -24,7 +24,7 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 
 import com.intel.oap.spark.sql.execution.datasources.v2.arrow._
-import com.sun.xml.internal.messaging.saaj.util.ByteOutputStream
+import com.sun.xml.messaging.saaj.util.ByteOutputStream
 import org.apache.arrow.dataset.jni.NativeMemoryPool
 import org.apache.arrow.memory.AllocationListener
 import org.apache.arrow.memory.BufferAllocator

--- a/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
+++ b/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
@@ -70,7 +70,7 @@ class ColumnarHashedRelation(
     // on off-heap memory and increase it or set the flag above. This tests whether it's
     // available:
     try {
-      createMethod.invoke(null, this, new Deallocator(obj, batch), null)
+      createMethod.invoke(null, this, new Deallocator(obj, batch))
     } catch {
       case e: IllegalAccessException =>
         // Don't throw an exception, but can't log here?

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
 
   <profiles>
     <profile>
+      <id>java11</id>
+      <properties>
+        <java.version>11</java.version>
+      </properties>
+    </profile>
+    <profile>
       <id>spark</id>
       <activation>
           <activeByDefault>true</activeByDefault>
@@ -128,6 +134,8 @@
     <!-- Scala 2.12.10 is the version for default spark 3.1 -->
     <scala.version>2.12.10</scala.version>
     <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <jackson.version>2.10.0</jackson.version>
     <scala.binary.version>2.12</scala.binary.version>
     <arrow.version>4.0.0</arrow.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This project doesn't support JDK 11 currently, the main reason is the use of `com.sun.xml.internal.messaging.saaj.util.ByteOutputStream` and `sun.misc.Cleaner`. Thus we change the reference of `com.sun.xml.internal.messaging.saaj.util.ByteOutputStream` to a three-party package, and change `sun.misc.Cleaner` to class reflection, and use `jdk.internal.ref.Cleaner` in JDK11.
Besides, we should add `--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED` to JVM options while running with JDK11.

## How was this patch tested?
Origin UT
