### PR TITLE
[DNM] fallback one entire stage if exits row op

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -153,7 +153,10 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
   // prefer to use columnar operators if set to true
   val enablePreferColumnar: Boolean =
     conf.getConfString("spark.oap.sql.columnar.preferColumnar", "true").toBoolean
-
+  
+  // fallback on entire stage even if there's only one row op
+  val enableStageFallback: Boolean =
+    conf.getConfString("spark.oap.sql.columnar.stagefallback", "true").toBoolean
   // fallback to row operators if there are several continous joins
   val joinOptimizationThrottle: Integer =
     conf.getConfString("spark.oap.sql.columnar.joinOptimizationLevel", "12").toInt

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/extension/ColumnarOverrides.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/extension/ColumnarOverrides.scala
@@ -73,6 +73,8 @@ case class ColumnarPreOverrides() extends Rule[SparkPlan] {
   def removeRowGuard(plan: SparkPlan): SparkPlan = plan match {
     case plan: RowGuard =>
       plan.child
+    case shuffle: ShuffleExchangeExec =>
+      shuffle
     case other =>
       val children = other.children.map(removeRowGuard)
       other.withNewChildren(children)


### PR DESCRIPTION

## What changes were proposed in this pull request?

This patch adds one configuration to allow fallback one entire stage
if there's one row op.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

