### PR TITLE
[NSE-778] Failed to find include file while running code gen

### DIFF
--- a/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -174,8 +174,22 @@ public class JniUtils {
       // only find all include file in the jar that contains JniUtils.class
       final String jarPath =
               JniUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-      extractResourcesToDirectory(
-              new JarFile(new File(jarPath)), folderToLoad, tmp_dir + "/" + "nativesql_include");
+      if (jarPath.endsWith(".jar")) {
+        extractResourcesToDirectory(
+                new JarFile(new File(jarPath)), folderToLoad, tmp_dir + "/" + "nativesql_include");
+      } else {
+        // For Maven test only
+        final URLConnection urlConnection =
+                JniUtils.class.getClassLoader().getResource("include").openConnection();
+        String path = urlConnection.getURL().toString();
+        if (urlConnection.getURL().toString().startsWith("file:")) {
+          // remove the prefix of "file:" from includePath
+          path = urlConnection.getURL().toString().substring(5);
+        }
+        final File folder = new File(path);
+        copyResourcesToDirectory(urlConnection,
+                tmp_dir + "/" + "nativesql_include", folder);
+      }
     }
   }
 

--- a/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -171,21 +171,11 @@ public class JniUtils {
         tmp_dir = System.getProperty("java.io.tmpdir");
       }
       final String folderToLoad = "include";
-      final URLConnection urlConnection = JniUtils.class.getClassLoader().getResource("include").openConnection();
-      if (urlConnection instanceof JarURLConnection) {
-        final JarFile jarFile = ((JarURLConnection) urlConnection).getJarFile();
-        extractResourcesToDirectory(jarFile, folderToLoad, tmp_dir + "/" + "nativesql_include");
-      } else {
-        // For Maven test only
-        String path = urlConnection.getURL().toString();
-        if (urlConnection.getURL().toString().startsWith("file:")) {
-          // remove the prefix of "file:" from includePath
-          path = urlConnection.getURL().toString().substring(5);
-        }
-        final File folder = new File(path);
-        copyResourcesToDirectory(urlConnection,
-                                 tmp_dir + "/" + "nativesql_include", folder);
-      }
+      // only find all include file in the jar that contains JniUtils.class
+      final String jarPath =
+              JniUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+      extractResourcesToDirectory(
+              new JarFile(new File(jarPath)), folderToLoad, tmp_dir + "/" + "nativesql_include");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
We may load wrong include files while calling `JniUtils.loadIncludeFromJar`, espetially when there is another jar has `include` resouces. Thus this pr try to solve this problem by loading the include file inside of the jar that contains JniUtils.class

## How was this patch tested?
Unit tests

