### PR TITLE
[NSE-823] Use `SPARK_VERSION_SHORT` instead os `SPARK_VERSION` to find SparkShims

### DIFF
--- a/shims/common/src/main/scala/com/intel/oap/sql/shims/SparkShimLoader.scala
+++ b/shims/common/src/main/scala/com/intel/oap/sql/shims/SparkShimLoader.scala
@@ -20,7 +20,7 @@ import java.util.ServiceLoader
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{SPARK_VERSION}
+import org.apache.spark.SPARK_VERSION_SHORT
 import org.apache.spark.internal.Logging
 
 object SparkShimLoader extends Logging {
@@ -36,7 +36,7 @@ object SparkShimLoader extends Logging {
   }
 
   def getSparkVersion: String = {
-      SPARK_VERSION
+    SPARK_VERSION_SHORT
   }
 
   def setSparkShimProviderClass(providerClass: String): Unit = {
@@ -48,8 +48,9 @@ object SparkShimLoader extends Logging {
     val sparkVersion = getSparkVersion
     logInfo(s"Loading Spark Shims for version: $sparkVersion")
 
-    //Load and filter the providers based on version
-    val shimProviders = ServiceLoader.load(classOf[SparkShimProvider]).asScala.filter(_.matches(sparkVersion))
+    // Load and filter the providers based on version
+    val shimProviders =
+      ServiceLoader.load(classOf[SparkShimProvider]).asScala.filter(_.matches(sparkVersion))
     if (shimProviders.size > 1) {
       throw new IllegalStateException(s"More than one SparkShimProvider found: $shimProviders")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
We should use `SPARK_VERSION_SHORT` to find `SparkShim`, not the `SPARK_ERSION`. As in use environment, `SPARK_VERSION` may be changed, the `SPARK_VERSION_SHORT` won't change.

## How was this patch tested?
Origin GA

