### PR TITLE
[NSE-746]Fix memory allocation in row to columnar 

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ArrowRowToColumnarExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ArrowRowToColumnarExec.scala
@@ -188,6 +188,7 @@ case class ArrowRowToColumnarExec(child: SparkPlan) extends UnaryExecNode {
               val output = ConverterUtils.fromArrowRecordBatch(arrowSchema, rb)
               val outputNumRows = rb.getLength
               ConverterUtils.releaseArrowRecordBatch(rb)
+              arrowBuf.close()
               last_cb = new ColumnarBatch(output.map(v => v.asInstanceOf[ColumnVector]).toArray, outputNumRows)
               elapse = System.nanoTime() - start
               processTime.set(NANOSECONDS.toMillis(elapse))

--- a/native-sql-engine/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
+++ b/native-sql-engine/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
@@ -37,6 +37,7 @@ class SortSuite extends SparkPlanTest with SharedSparkSession {
   override protected def sparkConf: SparkConf = {
     val conf = super.sparkConf
     conf.set("spark.memory.offHeap.size", String.valueOf("5000m"))
+    .set("spark.sql.inMemoryColumnarStorage.batchSize", "100")
   }
 
   test("basic sorting using ExternalSort") {


### PR DESCRIPTION

## What changes were proposed in this pull request?

This patch improves the memory allocation in r2c by doing
estimation based on first row. Also check the capacity during
the conversation and increase the buffer size if not enough

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>



## How was this patch tested?

pass jenkins
