### PR TITLE
[NSE-782] backport master changes to 1.3.1 branch

### DIFF
--- a/native-sql-engine/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
+++ b/native-sql-engine/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.types._
 class SortSuite extends SparkPlanTest with SharedSparkSession {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder
+  
+  override protected def sparkConf: SparkConf = {
+    val conf = super.sparkConf
+    conf.set("spark.memory.offHeap.size", String.valueOf("5000m"))
+    .set("spark.sql.inMemoryColumnarStorage.batchSize", "100")
+  }
 
   test("basic sorting using ExternalSort") {
 


### PR DESCRIPTION
* Optimize row to column memory allocation

This patch improves the memory allocation in r2c by doing
estimation based on first row. Also check the capacity during
the conversation and increase the buffer size if not enough

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

* fix leakage

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

* fix test

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

