### PR TITLE
[NSE-854] Small Shuffle Size disable wholestagecodegen

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -90,6 +90,12 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
     conf.getConfString("spark.oap.sql.columnar.forceshuffledhashjoin", "false").toBoolean &&
         enableCpu
 
+  val shuffleThresholdEnabled: Boolean =
+    conf.getConfString("spark.oap.sql.columnar.shuffleThresholdEnabled", "true")
+        .toBoolean
+  val shuffleThreshold: Int =
+    conf.getConfString("spark.oap.sql.columnar.shuffleThreshold", "1000000").toInt
+
   val resizeShuffledHashJoinInputPartitions: Boolean =
     conf.getConfString("spark.oap.sql.columnar.shuffledhashjoin.resizeinputpartitions", "false")
         .toBoolean && enableCpu

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/extension/ColumnarOverrides.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/extension/ColumnarOverrides.scala
@@ -55,7 +55,7 @@ import org.apache.spark.util.ShufflePartitionUtils
 
 import scala.collection.mutable
 
-case class ColumnarPreOverrides() extends Rule[SparkPlan] {
+case class ColumnarPreOverrides(session: SparkSession) extends Rule[SparkPlan] {
   val columnarConf: GazellePluginConfig = GazellePluginConfig.getSessionConf
   var isSupportAdaptive: Boolean = true
 
@@ -270,6 +270,20 @@ case class ColumnarPreOverrides() extends Rule[SparkPlan] {
       child match {
         case shuffle: ColumnarShuffleExchangeAdaptor =>
           logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
+          val metrics = shuffle.metrics
+          if (columnarConf.shuffleThresholdEnabled && metrics.contains("dataSize"))
+          {
+            val dataSize = metrics("dataSize").value
+            logWarning(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
+
+            if (dataSize > 0 && dataSize < columnarConf.shuffleThreshold)
+            {
+                logWarning(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
+                session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "true")
+            }
+          }
+
+
           if (columnarConf.enableArrowCoalesceBatches) {
             ArrowCoalesceBatchesExec(
               ColumnarCustomShuffleReaderExec(child, partitionSpecs))
@@ -282,6 +296,18 @@ case class ColumnarPreOverrides() extends Rule[SparkPlan] {
         case shuffleQueryStageExec: ShuffleQueryStageExec =>
           shuffleQueryStageExec.plan match {
             case s: ColumnarShuffleExchangeAdaptor =>
+              val metrics = s.metrics
+              if (columnarConf.shuffleThresholdEnabled && metrics.contains("dataSize"))
+              {
+                val dataSize = metrics("dataSize").value
+                logWarning(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
+
+                if (dataSize > 0 && dataSize < columnarConf.shuffleThreshold)
+                {
+                    logWarning(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
+                    session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "true")
+                }
+              }
               logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
               if (columnarConf.enableArrowCoalesceBatches) {
                 ArrowCoalesceBatchesExec(
@@ -291,6 +317,18 @@ case class ColumnarPreOverrides() extends Rule[SparkPlan] {
                   ColumnarCustomShuffleReaderExec(child, partitionSpecs))
               }
             case r @ ReusedExchangeExec(_, s: ColumnarShuffleExchangeAdaptor) =>
+              val metrics = s.metrics
+              if (columnarConf.shuffleThresholdEnabled && metrics.contains("dataSize"))
+              {
+                val dataSize = metrics("dataSize").value
+                logWarning(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
+
+                if (dataSize > 0 && dataSize < columnarConf.shuffleThreshold)
+                {
+                    logWarning(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
+                    session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "true")
+                }
+              }
               logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
               if (columnarConf.enableArrowCoalesceBatches) {
                 ArrowCoalesceBatchesExec(
@@ -474,15 +512,17 @@ case class ColumnarPostOverrides() extends Rule[SparkPlan] {
 case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule with Logging {
   def columnarEnabled =
     session.sqlContext.getConf("org.apache.spark.example.columnar.enabled", "true").trim.toBoolean
+  def codegendisable =
+    session.sqlContext.getConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "false").trim.toBoolean
   def conf = session.sparkContext.getConf
 
   // Do not create rules in class initialization as we should access SQLConf while creating the rules. At this time
   // SQLConf may not be there yet.
   def rowGuardOverrides = ColumnarGuardRule()
-  def preOverrides = ColumnarPreOverrides()
+  def preOverrides = ColumnarPreOverrides(session)
   def postOverrides = ColumnarPostOverrides()
 
-  val columnarWholeStageEnabled = conf.getBoolean("spark.oap.sql.columnar.wholestagecodegen", defaultValue = true)
+  def columnarWholeStageEnabled = conf.getBoolean("spark.oap.sql.columnar.wholestagecodegen", defaultValue = true) && !codegendisable
   def collapseOverrides = ColumnarCollapseCodegenStages(columnarWholeStageEnabled)
 
   var isSupportAdaptive: Boolean = true
@@ -519,7 +559,13 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
       val rule = postOverrides
       rule.setAdaptiveSupport(isSupportAdaptive)
       val tmpPlan = rule(plan)
-      collapseOverrides(tmpPlan)
+      val ret = collapseOverrides(tmpPlan)
+      if (codegendisable)
+      {
+        logWarning("postColumnarTransitions: resetting spark.oap.sql.columnar.codegendisableforsmallshuffles To false")
+        session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "false")
+      }
+      ret
     } else {
       plan
     }

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/extension/ColumnarOverrides.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/extension/ColumnarOverrides.scala
@@ -274,11 +274,11 @@ case class ColumnarPreOverrides(session: SparkSession) extends Rule[SparkPlan] {
           if (columnarConf.shuffleThresholdEnabled && metrics.contains("dataSize"))
           {
             val dataSize = metrics("dataSize").value
-            logWarning(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
+            logDebug(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
 
             if (dataSize > 0 && dataSize < columnarConf.shuffleThreshold)
             {
-                logWarning(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
+                logDebug(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
                 session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "true")
             }
           }
@@ -300,11 +300,11 @@ case class ColumnarPreOverrides(session: SparkSession) extends Rule[SparkPlan] {
               if (columnarConf.shuffleThresholdEnabled && metrics.contains("dataSize"))
               {
                 val dataSize = metrics("dataSize").value
-                logWarning(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
+                logDebug(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
 
                 if (dataSize > 0 && dataSize < columnarConf.shuffleThreshold)
                 {
-                    logWarning(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
+                    logDebug(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
                     session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "true")
                 }
               }
@@ -321,11 +321,11 @@ case class ColumnarPreOverrides(session: SparkSession) extends Rule[SparkPlan] {
               if (columnarConf.shuffleThresholdEnabled && metrics.contains("dataSize"))
               {
                 val dataSize = metrics("dataSize").value
-                logWarning(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
+                logDebug(s"shuffle size ${dataSize} threshold ${columnarConf.shuffleThreshold}")
 
                 if (dataSize > 0 && dataSize < columnarConf.shuffleThreshold)
                 {
-                    logWarning(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
+                    logDebug(s"Setting spark.oap.sql.columnar.codegendisableforsmallshuffles to true")
                     session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "true")
                 }
               }
@@ -562,7 +562,7 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
       val ret = collapseOverrides(tmpPlan)
       if (codegendisable)
       {
-        logWarning("postColumnarTransitions: resetting spark.oap.sql.columnar.codegendisableforsmallshuffles To false")
+        logDebug("postColumnarTransitions: resetting spark.oap.sql.columnar.codegendisableforsmallshuffles To false")
         session.sqlContext.setConf("spark.oap.sql.columnar.codegendisableforsmallshuffles", "false")
       }
       ret

--- a/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -333,7 +333,6 @@ case class ColumnarCollapseCodegenStages(
     if (columnarWholeStageEnabled) {
       insertWholeStageCodegen(plan)
     } else {
-      logWarning("columnarWholeStageEnabled is disabled, not calling insertWholeStageCodegen")
       plan
     }
   }

--- a/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/native-sql-engine/core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -333,6 +333,7 @@ case class ColumnarCollapseCodegenStages(
     if (columnarWholeStageEnabled) {
       insertWholeStageCodegen(plan)
     } else {
+      logWarning("columnarWholeStageEnabled is disabled, not calling insertWholeStageCodegen")
       plan
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In case of queries with small shuffle size the elapsed time is increased when running with gazelle. One option for improvement is to skip the wholestagegencode step for such queries. This PR add the option to use such feature by enabling the flag
"spark.oap.sql.columnar.shuffleThresholdEnabled" and setting the shuffle size threshold for small shuffles "spark.oap.sql.columnar.shuffleThreshold". 

When a small shuffle size in detected in a stage an internal flag: 
spark.oap.sql.columnar.codegendisableforsmallshuffles is turned on for the code gen to disabled. 
The flag is turned off at the end of the stage.

## How was this patch tested?

Ran TPCDS on Dataproc/GCP
For q2 there was a slight enhancement in performance
