### PR TITLE
[NSE-876] Fix writing arrow hang with OutputWriter.path

### DIFF
--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowFileFormat.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowFileFormat.scala
@@ -81,8 +81,9 @@ class ArrowFileFormat extends FileFormat with DataSourceRegister with Serializab
 
       override def newInstance(path: String, dataSchema: StructType,
           context: TaskAttemptContext): OutputWriter = {
+        val originPath = path
         val writeQueue = new ArrowWriteQueue(ArrowUtils.toArrowSchema(dataSchema),
-          ArrowUtils.getFormat(arrowOptions), path)
+          ArrowUtils.getFormat(arrowOptions), originPath)
 
         new OutputWriter {
           override def write(row: InternalRow): Unit = {
@@ -97,7 +98,7 @@ class ArrowFileFormat extends FileFormat with DataSourceRegister with Serializab
 
           // Do NOT add override keyword for compatibility on spark 3.1.
           def path(): String = {
-            path
+            originPath
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix writing arrow hang with OutputWriter.path.
```
"Executor task launch worker for task 0.0 in stage 2.0 (TID 2)" #182 daemon prio=5 os_prio=0 tid=0x00007fe734024000 nid=0x573c runnable [0x00007fe50cfe3000]
   java.lang.Thread.State: RUNNABLE
	at com.intel.oap.spark.sql.execution.datasources.arrow.ArrowFileFormat$$anon$1$$anon$2.path(ArrowFileFormat.scala:102)
	at org.apache.spark.sql.execution.datasources.SingleDirectoryDataWriter.$anonfun$write$2(FileFormatDataWriter.scala:176)
	at org.apache.spark.sql.execution.datasources.SingleDirectoryDataWriter.$anonfun$write$2$adapted(FileFormatDataWriter.scala:176)
```


## How was this patch tested?
unit tests

