### PR TITLE
[NSE-892] Allow to use jar cmd not in PATH

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -622,6 +622,12 @@ arrow::Status CompileCodes(std::string codes, std::string signature) {
   }
   std::string env_gcc = std::string(env_gcc_);
 
+  const char* env_jar_ = std::getenv("JAR");
+  if (env_jar_ == nullptr) {
+    env_jar_ = "jar";
+  }
+  std::string env_jar = std::string(env_jar_);
+
   std::string env_codegen_option = " -O3 -march=native ";
   char* env_codegen_option_ = std::getenv("CODEGEN_OPTION");
 
@@ -664,9 +670,9 @@ arrow::Status CompileCodes(std::string codes, std::string signature) {
          " -lspark_columnar_jni -shared && ";
 
   // package
-  cmd += "cd " + outpath + " && jar -cf spark-columnar-plugin-codegen-precompile-" +
-         signature + ".jar spark-columnar-plugin-codegen-" + signature + ".so 2>" +
-         logfile;
+  cmd += "cd " + outpath + " && " + env_jar +
+         " -cf spark-columnar-plugin-codegen-precompile-" + signature +
+         ".jar spark-columnar-plugin-codegen-" + signature + ".so 2>" + logfile;
 
 #ifdef DEBUG
   std::cout << cmd << std::endl;


### PR DESCRIPTION


## What changes were proposed in this pull request?

This patch adds one more configuration for deployment with jar cmd
not in PATH

export JAR=/path/to/jar
--conf spark.executorEnv.JAR=/path/to/jar

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?

Pass jenkins

