### PR TITLE
[NSE-857] Further optimizations of validity buffer split

### DIFF
--- a/native-sql-engine/cpp/src/shuffle/splitter.cc
+++ b/native-sql-engine/cpp/src/shuffle/splitter.cc
@@ -32,6 +32,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <x86intrin.h>
 
 #include "shuffle/utils.h"
 #include "utils/macros.h"
@@ -1173,8 +1174,6 @@ arrow::Status Splitter::SplitFixedWidthValueBuffer(const arrow::RecordBatch& rb)
         break;
 #endif
       case 1:  // arrow::BooleanType::type_id:
-        std::copy(partition_buffer_idx_base_.begin(), partition_buffer_idx_base_.end(),
-                  partition_buffer_dst_offset_.begin());
 #ifdef PROCESSROW
         // assume batch size = 32k; reducer# = 4K; row/reducer = 8
         for (auto pid = 0; pid < num_partitions_; pid++) {
@@ -1184,17 +1183,19 @@ arrow::Status Splitter::SplitFixedWidthValueBuffer(const arrow::RecordBatch& rb)
           auto size = reducer_offset_offset_[pid + 1];
           for (r; r < size; r++) {
             auto src_offset = reducer_offsets_[r]; /*16k*/
-            row_offset_type dst_offset = partition_buffer_dst_offset_[pid];
+            row_offset_type dst_offset = partition_buffer_idx_base_[pid];
             uint8_t dst = dst_addrs[pid][dst_offset >> 3];
             dst ^=
                 (dst >> (dst_offset & 7) ^ src_addr[src_offset >> 3] >> (src_offset & 7))
                 << (dst_offset & 7);
             dst_addrs[pid][dst_offset >> 3] = dst;
             _mm_prefetch(&(src_addr)[src_offset + 64], _MM_HINT_T0);
-            partition_buffer_dst_offset_[pid]++;
+            dst_offset++;
           }
         }
 #else
+        std::copy(partition_buffer_idx_base_.begin(), partition_buffer_idx_base_.end(),
+                  partition_buffer_dst_offset_.begin());
         for (auto row = 0; row < num_rows; ++row) {
           auto pid = partition_id_[row];
           row_offset_type dst_offset = partition_buffer_dst_offset_[pid];
@@ -1404,9 +1405,82 @@ arrow::Status Splitter::SplitFixedWidthValidityBuffer(const arrow::RecordBatch& 
         }
       }
       auto src_addr = const_cast<uint8_t*>(rb.column_data(col_idx)->buffers[0]->data());
+#ifdef PROCESSROW
+#if 0
+      // assume batch size = 32k; reducer# = 4K; row/reducer = 8
+      for (auto pid = 0; pid < num_partitions_; pid++) {
+        // set the last byte
+        if (partition_id_cnt_[pid] > 0 && dst_addrs[pid] != nullptr) {
+          auto dst_pid_base = 
+              reinterpret_cast<uint8_t*>(partition_buffer_dst_addr_[pid]); /*32k*/
+          auto r = reducer_offset_offset_[pid];                            /*8k*/
+          auto size = reducer_offset_offset_[pid + 1];
+          row_offset_type dst_offset = partition_buffer_idx_base_[pid];
+          row_offset_type dst_offset_in_byte = (8 - (dst_offset & 0x7)) & 0x7;
+          row_offset_type dst_idx_byte = dst_offset_in_byte;
+          uint8_t dst = dst_addrs[pid][dst_offset >> 3];
+          for (r; r < size && dst_idx_byte>0; r++, dst_idx_byte--) {
+            auto src_offset = reducer_offsets_[r]; /*16k*/
+            uint8_t src = src_addr[src_offset >> 3];
+            src = src >> (src_offset & 7) | 0xfe; // get the bit in bit 0, other bits set to 1
+            src = __rolb(src, 8-dst_idx_byte);
+            dst = dst & src; // only take the useful bit.
+          }
+          dst_addrs[pid][dst_offset >> 3] = dst;
+          dst_offset += dst_offset_in_byte;
+          //now dst_offset is 8 aligned
+          for (r; r + 8 < size ; r+=8) {
+            uint8_t src=0;
+            auto src_offset = reducer_offsets_[r]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst = src >> (src_offset & 7) | 0xfe; // get the bit in bit 0, other bits set to 1
+
+            src_offset = reducer_offsets_[r+1]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 1 | 0xfd; // get the bit in bit 0, other bits set to 1
+
+            src_offset = reducer_offsets_[r+2]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 2 | 0xfb; // get the bit in bit 0, other bits set to 1
+
+            src_offset = reducer_offsets_[r+3]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 3 | 0xf7; // get the bit in bit 0, other bits set to 1
+
+            src_offset = reducer_offsets_[r+4]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 4 | 0xef; // get the bit in bit 0, other bits set to 1
+            
+            src_offset = reducer_offsets_[r+5]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 5 | 0xdf; // get the bit in bit 0, other bits set to 1
+            
+            src_offset = reducer_offsets_[r+6]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 6 | 0xbf; // get the bit in bit 0, other bits set to 1
+            
+            src_offset = reducer_offsets_[r+7]; /*16k*/
+            src = src_addr[src_offset >> 3];
+            dst &= src >> (src_offset & 7) << 7 | 0x7f; // get the bit in bit 0, other bits set to 1
+
+            dst_addrs[pid][dst_offset >> 3] = dst;
+            dst_offset+=8;
+          }
+          dst = dst_addrs[pid][dst_offset >> 3];
+          dst_idx_byte=0;
+          for (r; r < size; r++,dst_idx_byte++) {
+            auto src_offset = reducer_offsets_[r]; /*16k*/
+            uint8_t src = src_addr[src_offset >> 3];
+            src = src >> (src_offset & 7) | 0xfe; // get the bit in bit 0, other bits set to 1
+            src = __rolb(src, dst_idx_byte);
+            dst = dst & src; // only take the useful bit.
+          }
+          dst_addrs[pid][dst_offset >> 3] = dst;*/
+        }
+      }
+#else
       std::copy(partition_buffer_idx_base_.begin(), partition_buffer_idx_base_.end(),
                 partition_buffer_dst_offset_.begin());
-#ifdef PROCESSROW
       // assume batch size = 32k; reducer# = 4K; row/reducer = 8
       for (auto pid = 0; pid < num_partitions_; pid++) {
         auto dst_pid_base =
@@ -1434,7 +1508,10 @@ arrow::Status Splitter::SplitFixedWidthValidityBuffer(const arrow::RecordBatch& 
           dst_addrs[pid][lastoffset >> 3] = dst;
         }
       }
+#endif
 #else
+      std::copy(partition_buffer_idx_base_.begin(), partition_buffer_idx_base_.end(),
+                partition_buffer_dst_offset_.begin());
       for (auto row = 0; row < num_rows; ++row) {
         auto pid = partition_id_[row];
         auto dst_offset = partition_buffer_dst_offset_[pid];

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -131,7 +131,7 @@ class Splitter {
 #if defined(COLUMNAR_PLUGIN_USE_AVX512)
   arrow::Status SplitFixedWidthValueBufferAVX(const arrow::RecordBatch& rb);
 #endif
-  arrow::Status SplitBoolType(const uint8_t* src_addr, std::vector<uint8_t*>& dst_addrs);
+  arrow::Status SplitBoolType(const uint8_t* src_addr, const std::vector<uint8_t*>& dst_addrs);
   
   arrow::Status SplitFixedWidthValidityBuffer(const arrow::RecordBatch& rb);
 

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -131,8 +131,9 @@ class Splitter {
 #if defined(COLUMNAR_PLUGIN_USE_AVX512)
   arrow::Status SplitFixedWidthValueBufferAVX(const arrow::RecordBatch& rb);
 #endif
-  arrow::Status SplitBoolType(const uint8_t* src_addr, const std::vector<uint8_t*>& dst_addrs);
-  
+  arrow::Status SplitBoolType(const uint8_t* src_addr,
+                              const std::vector<uint8_t*>& dst_addrs);
+
   arrow::Status SplitFixedWidthValidityBuffer(const arrow::RecordBatch& rb);
 
   arrow::Status SplitBinaryArray(const arrow::RecordBatch& rb);

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -131,7 +131,8 @@ class Splitter {
 #if defined(COLUMNAR_PLUGIN_USE_AVX512)
   arrow::Status SplitFixedWidthValueBufferAVX(const arrow::RecordBatch& rb);
 #endif
-
+  arrow::Status SplitBoolType(const uint8_t* src_addr, std::vector<uint8_t*>& dst_addrs);
+  
   arrow::Status SplitFixedWidthValidityBuffer(const arrow::RecordBatch& rb);
 
   arrow::Status SplitBinaryArray(const arrow::RecordBatch& rb);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Previous implementation of validity buffer split performance is too bad.

<table>
<tr>
	<td> no validity buffer
	<td> 1.55
<tr>
	<td> w/ validity buffer, before opt
	<td> 2.51
<tr>
	<td>w/ validity buffer, after opt
	<td> 2.01
</table>

From profile data, validity buffer split still takes more time than value copy. Most of the time is spending on the first touch of dst buffer

```
67.32%  BenchmarkShuffl  libspark_columnar_jni.so  [.] sparkcolumnarplugin::shuffle::Splitter::SplitBoolType                                                                              
25.96%  BenchmarkShuffl  libspark_columnar_jni.so  [.] sparkcolumnarplugin::shuffle::Splitter::SplitFixedWidthValueBuffer                                                                 
 1.81%  BenchmarkShuffl  libspark_columnar_jni.so  [.] sparkcolumnarplugin::shuffle::RoundRobinSplitter::ComputeAndCountPartitionId                                                       
 1.48%  BenchmarkShuffl  libc-2.17.so              [.] __memmove_ssse3_back                                                                                                               
 1.31%  BenchmarkShuffl  libspark_columnar_jni.so  [.] sparkcolumnarplugin::shuffle::Splitter::DoSplit                                                                                    
 1.02%  BenchmarkShuffl  libspark_columnar_jni.so  [.] sparkcolumnarplugin::shuffle::Splitter::SplitFixedWidthValidityBuffer    
```         


## How was this patch tested?
