### PR TITLE
[NSE-856] Optimize of string/binary split

### DIFF
--- a/native-sql-engine/cpp/CMakeLists.txt
+++ b/native-sql-engine/cpp/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(spark_columnar_plugin)
 
-#add_definitions(-DSKIPWRITE -DSKIPCOMPRESS -DPROCESSROW)
-add_definitions(-DPROCESSROW)
+#add_definitions(-DSKIPWRITE -DSKIPCOMPRESS )
+add_definitions(-DAVX512SUPPORT )
 
 #add_compile_options(-g)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/native-sql-engine/cpp/CMakeLists.txt
+++ b/native-sql-engine/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(spark_columnar_plugin)
 
 #add_definitions(-DSKIPWRITE -DSKIPCOMPRESS )
-add_definitions(-DAVX512SUPPORT )
+#add_definitions(-DAVX512SUPPORT )
 
 #add_compile_options(-g)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -51,7 +51,7 @@ void print_trace(void) {
 namespace sparkcolumnarplugin {
 namespace shuffle {
 
-#define ALIGNMENT 2048 * 1024
+#define ALIGNMENT 64
 
 const int batch_buffer_size = 32768;
 const int split_buffer_size = 8192;
@@ -127,7 +127,7 @@ class LargePageMemoryPool : public MemoryPool {
       return pool_->Reallocate(old_size, new_size, ptr);
     } else {
       Status st = pool_->AlignReallocate(old_size, new_size, ptr, ALIGNMENT);
-      // madvise(*ptr, new_size, /*MADV_HUGEPAGE */ 14);
+       madvise(*ptr, new_size, /*MADV_HUGEPAGE */ 14);
       return st;
     }
 #else
@@ -320,28 +320,30 @@ class BenchmarkShuffleSplit_CacheScan_Benchmark : public BenchmarkShuffleSplit {
                 int64_t& num_batches, int64_t& num_rows, int64_t& split_time,
                 const int num_partitions, SplitOptions options, benchmark::State& state) {
     std::vector<int> local_column_indices;
-    local_column_indices.push_back(0);
+    //local_column_indices.push_back(0);
     /*    local_column_indices.push_back(0);
         local_column_indices.push_back(1);
         local_column_indices.push_back(2);
         local_column_indices.push_back(4);
         local_column_indices.push_back(5);
         local_column_indices.push_back(6);
-        local_column_indices.push_back(7);*/
+        local_column_indices.push_back(7);
+*/
+        local_column_indices.push_back(8);
+        local_column_indices.push_back(9);
+        local_column_indices.push_back(13);
+        local_column_indices.push_back(14);
+        local_column_indices.push_back(15);
 
     std::shared_ptr<arrow::Schema> local_schema;
-    local_schema = std::make_shared<arrow::Schema>(*schema.get());
-
-    /*    ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(15));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(14));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(13));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(12));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(11));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(10));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(9));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(8));
-        ARROW_ASSIGN_OR_THROW(local_schema, local_schema->RemoveField(3));
-    */
+    arrow::FieldVector fields;
+    fields.push_back(schema->field(8));
+    fields.push_back(schema->field(9));
+    fields.push_back(schema->field(13));
+    fields.push_back(schema->field(14));
+    fields.push_back(schema->field(15));
+    local_schema = std::make_shared<arrow::Schema>(fields);
+    
     if (state.thread_index() == 0) std::cout << local_schema->ToString() << std::endl;
 
     ARROW_ASSIGN_OR_THROW(splitter,

--- a/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -51,7 +51,7 @@ void print_trace(void) {
 namespace sparkcolumnarplugin {
 namespace shuffle {
 
-#define ALIGNMENT 64
+#define ALIGNMENT 2*1024*1024
 
 const int batch_buffer_size = 32768;
 const int split_buffer_size = 8192;

--- a/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -51,7 +51,7 @@ void print_trace(void) {
 namespace sparkcolumnarplugin {
 namespace shuffle {
 
-#define ALIGNMENT 2*1024*1024
+#define ALIGNMENT 2 * 1024 * 1024
 
 const int batch_buffer_size = 32768;
 const int split_buffer_size = 8192;

--- a/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/native-sql-engine/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -127,7 +127,7 @@ class LargePageMemoryPool : public MemoryPool {
       return pool_->Reallocate(old_size, new_size, ptr);
     } else {
       Status st = pool_->AlignReallocate(old_size, new_size, ptr, ALIGNMENT);
-       madvise(*ptr, new_size, /*MADV_HUGEPAGE */ 14);
+      madvise(*ptr, new_size, /*MADV_HUGEPAGE */ 14);
       return st;
     }
 #else
@@ -320,7 +320,7 @@ class BenchmarkShuffleSplit_CacheScan_Benchmark : public BenchmarkShuffleSplit {
                 int64_t& num_batches, int64_t& num_rows, int64_t& split_time,
                 const int num_partitions, SplitOptions options, benchmark::State& state) {
     std::vector<int> local_column_indices;
-    //local_column_indices.push_back(0);
+    // local_column_indices.push_back(0);
     /*    local_column_indices.push_back(0);
         local_column_indices.push_back(1);
         local_column_indices.push_back(2);
@@ -329,11 +329,11 @@ class BenchmarkShuffleSplit_CacheScan_Benchmark : public BenchmarkShuffleSplit {
         local_column_indices.push_back(6);
         local_column_indices.push_back(7);
 */
-        local_column_indices.push_back(8);
-        local_column_indices.push_back(9);
-        local_column_indices.push_back(13);
-        local_column_indices.push_back(14);
-        local_column_indices.push_back(15);
+    local_column_indices.push_back(8);
+    local_column_indices.push_back(9);
+    local_column_indices.push_back(13);
+    local_column_indices.push_back(14);
+    local_column_indices.push_back(15);
 
     std::shared_ptr<arrow::Schema> local_schema;
     arrow::FieldVector fields;
@@ -343,7 +343,7 @@ class BenchmarkShuffleSplit_CacheScan_Benchmark : public BenchmarkShuffleSplit {
     fields.push_back(schema->field(14));
     fields.push_back(schema->field(15));
     local_schema = std::make_shared<arrow::Schema>(fields);
-    
+
     if (state.thread_index() == 0) std::cout << local_schema->ToString() << std::endl;
 
     ARROW_ASSIGN_OR_THROW(splitter,

--- a/native-sql-engine/cpp/src/shuffle/splitter.cc
+++ b/native-sql-engine/cpp/src/shuffle/splitter.cc
@@ -594,7 +594,6 @@ arrow::Status Splitter::CacheRecordBatch(int32_t partition_id, bool reset_buffer
     partition_cached_recordbatch_[partition_id].push_back(std::move(payload));
     partition_buffer_idx_base_[partition_id] = 0;
   }
-
   return arrow::Status::OK();
 }
 
@@ -622,14 +621,15 @@ arrow::Status Splitter::AllocatePartitionBuffers(int32_t partition_id, int32_t n
 
         std::shared_ptr<arrow::Buffer> offset_buffer;
         std::shared_ptr<arrow::Buffer> validity_buffer = nullptr;
-        auto value_buf_size = binary_array_empirical_size_[binary_idx] * new_size;
+        auto value_buf_size = binary_array_empirical_size_[binary_idx] * new_size+1024;
         ARROW_ASSIGN_OR_RAISE(
             std::shared_ptr<arrow::Buffer> value_buffer,
             arrow::AllocateResizableBuffer(value_buf_size, options_.memory_pool));
         ARROW_RETURN_NOT_OK(
-            AllocateBufferFromPool(offset_buffer, new_size * sizeof_binary_offset));
+            AllocateBufferFromPool(offset_buffer, new_size * sizeof_binary_offset+1));
         // set the first offset to 0
-        memset(offset_buffer->mutable_data(), 0, 8);
+        uint8_t* offsetaddr = offset_buffer->mutable_data();
+        memset(offsetaddr, 0, 8);
 
         partition_binary_addrs_[binary_idx][partition_id] = BinaryBuff(
             value_buffer->mutable_data(), offset_buffer->mutable_data(), value_buf_size);
@@ -839,6 +839,7 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb) {
       if (ARROW_PREDICT_FALSE(binary_array_empirical_size_[i - fixed_width_col_cnt_] ==
                              0)) {
         binary_array_empirical_size_[i - fixed_width_col_cnt_] = length % num_rows == 0 ? length / num_rows:length / num_rows+1;
+        //std::cout << "avg str length col = " << i - fixed_width_col_cnt_ << " len = " << binary_array_empirical_size_[i - fixed_width_col_cnt_] << std::endl;
       }
     }
   }
@@ -1174,19 +1175,19 @@ arrow::Status Splitter::SplitBinaryType(const uint8_t* src_addr, const T* src_of
     auto dst_value_base =
         partition_binary_buffer_idx_offset_[pid].valueptr + dst_offset_base[0];
     //_mm_prefetch(&partition_binary_buffer_idx_offset_[pid+1], _MM_HINT_T0);
-    auto r = reducer_offset_offset_[pid]; /*8k*/
+    auto r = reducer_offset_offset_[pid]; /*128k*/
     auto size = reducer_offset_offset_[pid + 1];
+    auto capacity = partition_binary_buffer_idx_offset_[pid].value_capacity;
     for (r; r < size; r++) {
-      auto src_offset = reducer_offsets_[r]; /*16k*/
+      auto src_offset = reducer_offsets_[r]; /*128k*/
       auto strlength = src_offset_addr[src_offset + 1] - src_offset_addr[src_offset];
       dst_offset_base[1] = dst_offset_base[0] + strlength;
-      if(ARROW_PREDICT_FALSE(dst_offset_base[1] >= partition_binary_buffer_idx_offset_[pid].value_capacity))
+      if(ARROW_PREDICT_FALSE(dst_offset_base[1] >= capacity))
       {
         //allocate value buffer again
-        auto oldsize = partition_binary_buffer_idx_offset_[pid].value_capacity;
         //enlarge the buffer by 1.5x
         auto value_buf_size = partition_binary_buffer_idx_offset_[pid].value_capacity +
-            std::max((partition_binary_buffer_idx_offset_[pid].value_capacity >> 1),(uint64_t)strlength);
+            std::max((capacity >> 1),(uint64_t)strlength);
         
         auto value_buffer = std::static_pointer_cast<arrow::ResizableBuffer>(partition_buffers_[fixed_width_col_cnt_ + binary_idx][pid][2]);
         value_buffer->Reserve(value_buf_size);
@@ -1194,6 +1195,7 @@ arrow::Status Splitter::SplitBinaryType(const uint8_t* src_addr, const T* src_of
         partition_binary_buffer_idx_offset_[pid].valueptr = dst_addrs[pid].valueptr = value_buffer->mutable_data();
         partition_binary_buffer_idx_offset_[pid].value_capacity = dst_addrs[pid].value_capacity = value_buf_size;
         dst_value_base= partition_binary_buffer_idx_offset_[pid].valueptr + dst_offset_base[0];
+        std::cout << " value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[0] << " dst_end " << dst_offset_base[1] << " old size = " << capacity << " new size = "  << value_buf_size << " row = " << partition_buffer_idx_base_[pid] << " strlen = " << strlength << std::endl;
       }
       
       // write the variable value
@@ -1208,7 +1210,7 @@ arrow::Status Splitter::SplitBinaryType(const uint8_t* src_addr, const T* src_of
       __m256i v = _mm256_maskz_loadu_epi8(mask, value_src_ptr + k);
       _mm256_mask_storeu_epi8(dst_value_base + k, mask, v);
 
-      //memcpy(dst_value_base, src_addr + src_offset_addr[src_offset], strlength);
+//      memcpy(dst_value_base, src_addr + src_offset_addr[src_offset], strlength);
       dst_offset_base++;
       dst_value_base += strlength;
       _mm_prefetch(src_addr + src_offset_addr[src_offset]+64, _MM_HINT_T1);

--- a/native-sql-engine/cpp/src/shuffle/splitter.cc
+++ b/native-sql-engine/cpp/src/shuffle/splitter.cc
@@ -1249,7 +1249,8 @@ arrow::Status Splitter::SplitBinaryType(const uint8_t* src_addr, const T* src_of
                   << " strlen = " << strlength << std::endl;
       }
       auto value_src_ptr = src_addr + src_offset_addr[src_offset];
-#if NATIVE_AVX512 == ON
+//#if NATIVE_AVX512 == ON
+#ifdef AVX512SUPPORT
       // write the variable value
       T k;
       for (k = 0; k + 32 < strlength; k += 32) {

--- a/native-sql-engine/cpp/src/shuffle/splitter.cc
+++ b/native-sql-engine/cpp/src/shuffle/splitter.cc
@@ -515,6 +515,13 @@ arrow::Status Splitter::CacheRecordBatch(int32_t partition_id, bool reset_buffer
           } else {
             // reset the offset
             partition_binary_addrs_[binary_idx][partition_id].value_offset = 0;
+            uint64_t dst_offset0 =
+                sizeof_binary_offset == 4
+                    ? reinterpret_cast<const arrow::BinaryType::offset_type*>(
+                          buffers[1]->data())[0]
+                    : reinterpret_cast<const arrow::LargeBinaryType::offset_type*>(
+                          buffers[1]->data())[0];
+            ARROW_CHECK_EQ(dst_offset0, 0);
           }
           binary_idx++;
           break;
@@ -830,9 +837,10 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb) {
           break;
         case arrow::LargeBinaryType::type_id:
         case arrow::LargeStringType::type_id:
-          length = reinterpret_cast<const arrow::StringType::offset_type*>(
-                       offsetbuf)[num_rows] -
-                   reinterpret_cast<const arrow::StringType::offset_type*>(offsetbuf)[0];
+          length =
+              reinterpret_cast<const arrow::LargeStringType::offset_type*>(
+                  offsetbuf)[num_rows] -
+              reinterpret_cast<const arrow::LargeStringType::offset_type*>(offsetbuf)[0];
           break;
       }
       // check every record batch, hope the length is more and more accurate

--- a/native-sql-engine/cpp/src/shuffle/splitter.cc
+++ b/native-sql-engine/cpp/src/shuffle/splitter.cc
@@ -821,7 +821,7 @@ arrow::Status Splitter::DoSplit(const arrow::RecordBatch& rb) {
     if (ARROW_PREDICT_TRUE(arr->buffers[1] != nullptr)) {
       auto offsetbuf = arr->buffers[1]->data();
       uint64_t length;
-      switch (column_type_id_[i]->id()) {
+      switch (column_type_id_[array_idx_[i]]->id()) {
         case arrow::BinaryType::type_id:
         case arrow::StringType::type_id:
           length = reinterpret_cast<const arrow::StringType::offset_type*>(

--- a/native-sql-engine/cpp/src/shuffle/splitter.cc
+++ b/native-sql-engine/cpp/src/shuffle/splitter.cc
@@ -1249,7 +1249,7 @@ arrow::Status Splitter::SplitBinaryType(const uint8_t* src_addr, const T* src_of
                   << " strlen = " << strlength << std::endl;
       }
       auto value_src_ptr = src_addr + src_offset_addr[src_offset];
-#ifdef AVX512SUPPORT
+#if NATIVE_AVX512 == ON
       // write the variable value
       T k;
       for (k = 0; k + 32 < strlength; k += 32) {

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -39,13 +39,11 @@ class Splitter {
  protected:
   struct BinaryBuff {
     BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c, uint64_t f)
-        : valueptr(v), offsetptr(o), value_capacity(c),
-        value_offset(f) {}
+        : valueptr(v), offsetptr(o), value_capacity(c), value_offset(f) {}
     BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c)
-        : valueptr(v), offsetptr(o), value_capacity(c),
-        value_offset(0) {}
-    BinaryBuff() : valueptr(nullptr), offsetptr(nullptr), value_capacity(0),
-        value_offset(0) {}
+        : valueptr(v), offsetptr(o), value_capacity(c), value_offset(0) {}
+    BinaryBuff()
+        : valueptr(nullptr), offsetptr(nullptr), value_capacity(0), value_offset(0) {}
 
     uint8_t* valueptr;
     uint8_t* offsetptr;
@@ -219,13 +217,12 @@ class Splitter {
   // col partid, 24 bytes each
   std::vector<std::vector<BinaryBuff>> partition_binary_addrs_;
 
-
   // col partid
   std::vector<std::vector<std::vector<std::shared_ptr<arrow::Buffer>>>>
       partition_buffers_;
   std::vector<std::vector<std::shared_ptr<arrow::ArrayBuilder>>> partition_list_builders_;
   // col partid
-  
+
   // slice the buffer for each reducer's column, in this way we can combine into large
   // page
   std::shared_ptr<arrow::ResizableBuffer> combine_buffer_;

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -141,6 +141,8 @@ class Splitter {
 
   arrow::Status DoSplit(const arrow::RecordBatch& rb);
 
+  row_offset_type CalculateSplitBatchSize(const arrow::RecordBatch& rb);
+
   template <typename T>
   arrow::Status SplitFixedType(const uint8_t* src_addr,
                                const std::vector<uint8_t*>& dst_addrs);

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -155,7 +155,7 @@ class Splitter {
 
   template <typename T>
   arrow::Status SplitBinaryType(const uint8_t* src_addr, const T* src_offset_addr,
-                                const std::vector<BinaryBuff>& dst_addrs);
+                                std::vector<BinaryBuff>& dst_addrs, const int binary_idx);
 
   arrow::Status SplitListArray(const arrow::RecordBatch& rb);
 

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -36,22 +36,16 @@ namespace sparkcolumnarplugin {
 namespace shuffle {
 
 class Splitter {
-
  protected:
- struct BinaryBuff{
-   BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c)
-        :valueptr(v),
-        offsetptr(o),
-        value_capacity(c){}
-   BinaryBuff()
-        :valueptr(nullptr),
-        offsetptr(nullptr),
-        value_capacity(0){}
+  struct BinaryBuff {
+    BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c)
+        : valueptr(v), offsetptr(o), value_capacity(c) {}
+    BinaryBuff() : valueptr(nullptr), offsetptr(nullptr), value_capacity(0) {}
 
-   uint8_t* valueptr;
-   uint8_t* offsetptr;
-   uint64_t value_capacity;
- };
+    uint8_t* valueptr;
+    uint8_t* offsetptr;
+    uint64_t value_capacity;
+  };
 
  public:
   static arrow::Result<std::shared_ptr<Splitter>> Make(
@@ -145,7 +139,7 @@ class Splitter {
 
   template <typename T>
   arrow::Status SplitFixedType(const uint8_t* src_addr,
-                              const std::vector<uint8_t*>& dst_addrs);
+                               const std::vector<uint8_t*>& dst_addrs);
 
   arrow::Status SplitFixedWidthValueBuffer(const arrow::RecordBatch& rb);
 
@@ -161,7 +155,7 @@ class Splitter {
 
   template <typename T>
   arrow::Status SplitBinaryType(const uint8_t* src_addr, const T* src_offset_addr,
-                              const std::vector<BinaryBuff>& dst_addrs);
+                                const std::vector<BinaryBuff>& dst_addrs);
 
   arrow::Status SplitListArray(const arrow::RecordBatch& rb);
 

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -155,7 +155,7 @@ class Splitter {
   arrow::Status SplitBoolType(const uint8_t* src_addr,
                               const std::vector<uint8_t*>& dst_addrs);
 
-  arrow::Status SplitFixedWidthValidityBuffer(const arrow::RecordBatch& rb);
+  arrow::Status SplitValidityBuffer(const arrow::RecordBatch& rb);
 
   arrow::Status SplitBinaryArray(const arrow::RecordBatch& rb);
 

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -225,8 +225,6 @@ class Splitter {
       partition_buffers_;
   std::vector<std::vector<std::shared_ptr<arrow::ArrayBuilder>>> partition_list_builders_;
   // col partid
-   // temp array to hold the destination pointer
-  std::vector<BinaryBuff> partition_binary_buffer_idx_offset_;
   
   // slice the buffer for each reducer's column, in this way we can combine into large
   // page

--- a/native-sql-engine/cpp/src/shuffle/splitter.h
+++ b/native-sql-engine/cpp/src/shuffle/splitter.h
@@ -38,13 +38,19 @@ namespace shuffle {
 class Splitter {
  protected:
   struct BinaryBuff {
+    BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c, uint64_t f)
+        : valueptr(v), offsetptr(o), value_capacity(c),
+        value_offset(f) {}
     BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c)
-        : valueptr(v), offsetptr(o), value_capacity(c) {}
-    BinaryBuff() : valueptr(nullptr), offsetptr(nullptr), value_capacity(0) {}
+        : valueptr(v), offsetptr(o), value_capacity(c),
+        value_offset(0) {}
+    BinaryBuff() : valueptr(nullptr), offsetptr(nullptr), value_capacity(0),
+        value_offset(0) {}
 
     uint8_t* valueptr;
     uint8_t* offsetptr;
     uint64_t value_capacity;
+    uint64_t value_offset;
   };
 
  public:
@@ -212,15 +218,16 @@ class Splitter {
   std::vector<std::vector<uint8_t*>> partition_fixed_width_value_addrs_;
   // col partid, 24 bytes each
   std::vector<std::vector<BinaryBuff>> partition_binary_addrs_;
-  // temp array to hold the destination pointer
-  std::vector<BinaryBuff> partition_binary_buffer_idx_offset_;
+
 
   // col partid
   std::vector<std::vector<std::vector<std::shared_ptr<arrow::Buffer>>>>
       partition_buffers_;
   std::vector<std::vector<std::shared_ptr<arrow::ArrayBuilder>>> partition_list_builders_;
   // col partid
-
+   // temp array to hold the destination pointer
+  std::vector<BinaryBuff> partition_binary_buffer_idx_offset_;
+  
   // slice the buffer for each reducer's column, in this way we can combine into large
   // page
   std::shared_ptr<arrow::ResizableBuffer> combine_buffer_;

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -242,8 +242,9 @@ TEST_F(SplitterTest, TestSingleSplitter) {
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
       ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
-//      std::cout << " result " << rb->column(j)->ToString() << std::endl;
-//      std::cout << " expected " << expected[i]->column(j)->ToString() << std::endl;
+      //      std::cout << " result " << rb->column(j)->ToString() << std::endl;
+      //      std::cout << " expected " << expected[i]->column(j)->ToString() <<
+      //      std::endl;
       ASSERT_TRUE(rb->column(j)->Equals(*expected[i]->column(j),
                                         EqualOptions::Defaults().diff_sink(&std::cout)));
     }

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -242,6 +242,8 @@ TEST_F(SplitterTest, TestSingleSplitter) {
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
       ASSERT_EQ(rb->column(j)->length(), rb->num_rows());
+//      std::cout << " result " << rb->column(j)->ToString() << std::endl;
+//      std::cout << " expected " << expected[i]->column(j)->ToString() << std::endl;
       ASSERT_TRUE(rb->column(j)->Equals(*expected[i]->column(j),
                                         EqualOptions::Defaults().diff_sink(&std::cout)));
     }

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -199,7 +199,7 @@ const std::vector<std::string> SplitterTest::input_data_2 = {
     "[null, null]",    "[null, null]",
     "[1, -1]",         "[100, null]",
     "[1, 1]",          R"([0.142857, -0.142857])",
-    "[true, false]",   R"(["bob", "alice"])",
+    "[true, false]",   R"(["bob", "alicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealice"])",
     R"([null, null])", R"([null, null])"};
 
 TEST_F(SplitterTest, TestSingleSplitter) {

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -319,7 +319,7 @@ TEST_F(SplitterTest, TestRoundRobinSplitter) {
 
 TEST_F(SplitterTest, TestSplitterMemoryLeak) {
   std::shared_ptr<arrow::MemoryPool> pool =
-      std::make_shared<MyMemoryPool>(9 * 1024 * 1024);
+      std::make_shared<MyMemoryPool>(17 * 1024 * 1024);
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -196,11 +196,16 @@ const std::vector<std::string> SplitterTest::input_data_1 = {
     R"(["-1.01", "2.01", "-3.01", null, "0.11", "3.14", "2.27", null, "-3.14", null])"};
 
 const std::vector<std::string> SplitterTest::input_data_2 = {
-    "[null, null]",    "[null, null]",
-    "[1, -1]",         "[100, null]",
-    "[1, 1]",          R"([0.142857, -0.142857])",
-    "[true, false]",   R"(["bob", "alicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealice"])",
-    R"([null, null])", R"([null, null])"};
+    "[null, null]",
+    "[null, null]",
+    "[1, -1]",
+    "[100, null]",
+    "[1, 1]",
+    R"([0.142857, -0.142857])",
+    "[true, false]",
+    R"(["bob", "alicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealicealice"])",
+    R"([null, null])",
+    R"([null, null])"};
 
 TEST_F(SplitterTest, TestSingleSplitter) {
   split_options_.buffer_size = 10;


### PR DESCRIPTION
## What changes were proposed in this pull request?

manually split the string/binary column. 
Previously we use builder to construct the string buffer. The PR create the destination buffers and read the src buffers, then split the column manually

The PR also removed some unused code