### PR TITLE
[NSE-912] Remove extra handleSafe costs

### DIFF
--- a/arrow-data-source/common/src/main/java/com/intel/oap/vectorized/ArrowColumnVectorUtils.java
+++ b/arrow-data-source/common/src/main/java/com/intel/oap/vectorized/ArrowColumnVectorUtils.java
@@ -1,0 +1,36 @@
+package com.intel.oap.vectorized;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * Utilities to help manipulate data associate with ColumnVectors. These should be used mostly
+ * for debugging or other non-performance critical paths.
+ * These utilities are mostly used to convert ColumnVectors into other formats.
+ */
+public class ArrowColumnVectorUtils {
+    /**
+     * Populates the entire `col` with `row[fieldIdx]`
+     * This is copied from {@link org.apache.spark.sql.execution.vectorized.ColumnVectorUtils#populate}.
+     * We changed the way to putByteArrays.
+     */
+    public static void populate(WritableColumnVector col, InternalRow row, int fieldIdx) {
+        ArrowWritableColumnVector arrowCol = (ArrowWritableColumnVector) col;
+        int capacity = arrowCol.getCapacity();
+
+        if (row.isNullAt(fieldIdx)) {
+            arrowCol.putNulls(0, capacity);
+        } else {
+            if (arrowCol.dataType() == DataTypes.StringType) {
+                UTF8String v = row.getUTF8String(fieldIdx);
+                byte[] bytes = v.getBytes();
+                arrowCol.putByteArrays(0, capacity, bytes, 0, bytes.length);
+            } else {
+                ColumnVectorUtils.populate(col, row, fieldIdx);
+            }
+        }
+    }
+}

--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowUtils.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowUtils.scala
@@ -23,7 +23,7 @@ import java.time.ZoneId
 
 import scala.collection.JavaConverters._
 
-import com.intel.oap.vectorized.ArrowWritableColumnVector
+import com.intel.oap.vectorized.{ArrowColumnVectorUtils, ArrowWritableColumnVector}
 import org.apache.arrow.dataset.file.FileSystemDatasetFactory
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
 import org.apache.arrow.vector.types.pojo.Schema
@@ -100,7 +100,7 @@ object ArrowUtils {
     }
     val partitionColumns = ArrowWritableColumnVector.allocateColumns(rowCount, partitionSchema)
     (0 until partitionColumns.length).foreach(i => {
-      ColumnVectorUtils.populate(partitionColumns(i), partitionValues, i)
+      ArrowColumnVectorUtils.populate(partitionColumns(i), partitionValues, i)
       partitionColumns(i).setValueCount(rowCount)
       partitionColumns(i).setIsConstant()
     })


### PR DESCRIPTION
## What changes were proposed in this pull request?
We are using setSafe to put partitionValues to Vectors while calling buildReaderWithPartitionValues. As showing in bellow image, it cost 11% cpu time to check handleSafe.
![image](https://user-images.githubusercontent.com/10897625/168756598-610bf494-1583-4d54-a261-84c2331a2f74.png)
Actually, the partitionValues written are all fixed length, so we can handleSafe once before writing into arrow, and use Vector.set instead of Vector.setSafe to remove extra handleSafe costs.


## How was this patch tested?
Unit tests

