### PR TITLE
[NSE-929] Support user defined spark extensions

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePlugin.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePlugin.scala
@@ -56,12 +56,14 @@ private[oap] class GazelleDriverPlugin extends DriverPlugin {
   }
 
   def setPredefinedConfigs(conf: SparkConf): Unit = {
-    if (conf.contains(SPARK_SESSION_EXTS_KEY)) {
-      throw new IllegalArgumentException("Spark extensions are already specified before " +
-          "enabling Gazelle plugin: " + conf.get(GazellePlugin.SPARK_SESSION_EXTS_KEY))
+    val extensions = conf.getOption(SPARK_SESSION_EXTS_KEY).getOrElse("")
+    if (extensions.contains(GAZELLE_SESSION_EXTENSION_NAME) ||
+      extensions.contains(GAZELLE_WRITE_SESSION_EXTENSION_NAME)) {
+      throw new IllegalArgumentException("Spark gazelle extensions are already specified before " +
+        "enabling Gazelle plugin: " + conf.get(GazellePlugin.SPARK_SESSION_EXTS_KEY))
     }
     conf.set(SPARK_SESSION_EXTS_KEY,
-      String.format("%s,%s", GAZELLE_SESSION_EXTENSION_NAME, GAZELLE_WRITE_SESSION_EXTENSION_NAME))
+      s"$GAZELLE_SESSION_EXTENSION_NAME,$GAZELLE_WRITE_SESSION_EXTENSION_NAME,$extensions")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When we start spark with user spark extension and gazelle, it will throw "Spark extensions are already specified before enabling Gazelle plugin: ". Actually, this exception should only be thrown when user set spark.sql.extensions to GazelleSessionExtensions or ArrowWriteExtension.


## How was this patch tested?
unit tests

