### PR TITLE
[NSE-126] set default codegen opt to O1

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/codegen_common.cc
@@ -628,7 +628,7 @@ arrow::Status CompileCodes(std::string codes, std::string signature) {
   }
   std::string env_jar = std::string(env_jar_);
 
-  std::string env_codegen_option = " -O3 -march=native ";
+  std::string env_codegen_option = " -O1 -march=native ";
   char* env_codegen_option_ = std::getenv("CODEGEN_OPTION");
 
   if (env_codegen_option_ != nullptr) {


### PR DESCRIPTION


## What changes were proposed in this pull request?

this patch sets default codegen opt level to O1, to reduce the codegen overhead

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

pass jenkins

