### PR TITLE
[NSE-979] Support reading parquet with case sensitive

### DIFF
--- a/arrow-data-source/common/src/main/scala/org/apache/spark/sql/execution/datasources/v2/arrow/SparkSchemaUtils.scala
+++ b/arrow-data-source/common/src/main/scala/org/apache/spark/sql/execution/datasources/v2/arrow/SparkSchemaUtils.scala
@@ -20,10 +20,10 @@ package org.apache.spark.sql.execution.datasources.v2.arrow
 import java.util.Objects
 import java.util.TimeZone
 
-import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.arrow.vector.types.pojo.{Field, Schema}
 
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.ArrowUtils
 
 object SparkSchemaUtils {
@@ -34,6 +34,11 @@ object SparkSchemaUtils {
 
   def toArrowSchema(schema: StructType, timeZoneId: String): Schema = {
     ArrowUtils.toArrowSchema(schema, timeZoneId)
+  }
+
+  def toArrowField(
+      name: String, dt: DataType, nullable: Boolean, timeZoneId: String): Field = {
+    ArrowUtils.toArrowField(name, dt, nullable, timeZoneId)
   }
 
   @deprecated  // experimental

--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowFileFormat.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowFileFormat.scala
@@ -34,8 +34,8 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.TaskAttemptContext
 import org.apache.parquet.hadoop.codec.CodecConfig
-import org.apache.spark.TaskContext
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriterFactory, PartitionedFile}

--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowFilters.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowFilters.scala
@@ -123,15 +123,15 @@ object ArrowFilters {
         createComparisonNode(
           "less_equal", caseInsensitiveFieldMap.getOrElse(attribute, attribute), value)
       case Not(child) =>
-        createNotNode(child)
+        createNotNode(child, caseInsensitiveFieldMap)
       case And(left, right) =>
-        createAndNode(left, right)
+        createAndNode(left, right, caseInsensitiveFieldMap)
       case Or(left, right) =>
-        createOrNode(left, right)
+        createOrNode(left, right, caseInsensitiveFieldMap)
       case IsNotNull(attribute) =>
-        createIsNotNullNode(attribute)
+        createIsNotNullNode(caseInsensitiveFieldMap.getOrElse(attribute, attribute))
       case IsNull(attribute) =>
-        createIsNullNode(attribute)
+        createIsNullNode(caseInsensitiveFieldMap.getOrElse(attribute, attribute))
       case _ => None // fixme complete this
     }
   }
@@ -155,8 +155,10 @@ object ArrowFilters {
     }
   }
 
-  def createNotNode(child: Filter): Option[TreeNode] = {
-    val translatedChild = translateFilter(child)
+  def createNotNode(
+      child: Filter,
+      caseInsensitiveFieldMap: Map[String, String]): Option[TreeNode] = {
+    val translatedChild = translateFilter(child, caseInsensitiveFieldMap)
     if (translatedChild.isEmpty) {
       return None
     }
@@ -186,9 +188,12 @@ object ArrowFilters {
                 .build()).build()).build()).build())
   }
 
-  def createAndNode(left: Filter, right: Filter): Option[TreeNode] = {
-    val translatedLeft = translateFilter(left)
-    val translatedRight = translateFilter(right)
+  def createAndNode(
+      left: Filter,
+      right: Filter,
+      caseInsensitiveFieldMap: Map[String, String]): Option[TreeNode] = {
+    val translatedLeft = translateFilter(left, caseInsensitiveFieldMap)
+    val translatedRight = translateFilter(right, caseInsensitiveFieldMap)
     if (translatedLeft.isEmpty || translatedRight.isEmpty) {
       return None
     }
@@ -200,9 +205,12 @@ object ArrowFilters {
       .build())
   }
 
-  def createOrNode(left: Filter, right: Filter): Option[TreeNode] = {
-    val translatedLeft = translateFilter(left)
-    val translatedRight = translateFilter(right)
+  def createOrNode(
+      left: Filter,
+      right: Filter,
+      caseInsensitiveFieldMap: Map[String, String]): Option[TreeNode] = {
+    val translatedLeft = translateFilter(left, caseInsensitiveFieldMap)
+    val translatedRight = translateFilter(right, caseInsensitiveFieldMap)
     if (translatedLeft.isEmpty || translatedRight.isEmpty) {
       return None
     }

--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowPartitionReaderFactory.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowPartitionReaderFactory.scala
@@ -19,10 +19,12 @@ package com.intel.oap.spark.sql.execution.datasources.v2.arrow
 import java.net.URLDecoder
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import com.intel.oap.spark.sql.execution.datasources.v2.arrow.ArrowPartitionReaderFactory.ColumnarBatchRetainer
 import com.intel.oap.spark.sql.execution.datasources.v2.arrow.ArrowSQLConf._
 import org.apache.arrow.dataset.scanner.ScanOptions
+import org.apache.arrow.vector.types.pojo.Schema
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
@@ -59,9 +61,27 @@ case class ArrowPartitionReaderFactory(
     val path = partitionedFile.filePath
     val factory = ArrowUtils.makeArrowDiscovery(URLDecoder.decode(path, "UTF-8"),
       partitionedFile.start, partitionedFile.length, options)
-    val dataset = factory.finish(ArrowUtils.toArrowSchema(readDataSchema))
+    val parquetFileFields = factory.inspect().getFields.asScala
+    val caseInsensitiveFieldMap = mutable.Map[String, String]()
+    val requiredFields = if (sqlConf.caseSensitiveAnalysis) {
+      new Schema(readDataSchema.map { field =>
+        parquetFileFields.find(_.getName.equals(field.name))
+          .getOrElse(ArrowUtils.toArrowField(field))
+      }.asJava)
+    } else {
+      new Schema(readDataSchema.map { readField =>
+        parquetFileFields.find(_.getName.equalsIgnoreCase(readField.name))
+          .map{ field =>
+            caseInsensitiveFieldMap += (readField.name -> field.getName)
+            field
+          }.getOrElse(ArrowUtils.toArrowField(readField))
+      }.asJava)
+    }
+    val dataset = factory.finish(requiredFields)
     val filter = if (enableFilterPushDown) {
-      ArrowFilters.translateFilters(ArrowFilters.pruneWithSchema(pushedFilters, readDataSchema))
+      ArrowFilters.translateFilters(
+        ArrowFilters.pruneWithSchema(pushedFilters, readDataSchema),
+        caseInsensitiveFieldMap.toMap)
     } else {
       org.apache.arrow.dataset.filter.Filter.EMPTY
     }

--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowUtils.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/v2/arrow/ArrowUtils.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import com.intel.oap.vectorized.{ArrowColumnVectorUtils, ArrowWritableColumnVector}
 import org.apache.arrow.dataset.file.FileSystemDatasetFactory
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch
-import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.arrow.vector.types.pojo.{Field, Schema}
 import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -34,10 +34,9 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.v2.arrow.{SparkMemoryUtils, SparkSchemaUtils}
 import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.sql.vectorized.ColumnVector
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 object ArrowUtils {
 
@@ -87,6 +86,11 @@ object ArrowUtils {
   def toArrowSchema(t: StructType): Schema = {
     // fixme this might be platform dependent
     SparkSchemaUtils.toArrowSchema(t, SparkSchemaUtils.getLocalTimezoneID())
+  }
+
+  def toArrowField(t: StructField): Field = {
+    SparkSchemaUtils.toArrowField(
+      t.name, t.dataType, t.nullable, SparkSchemaUtils.getLocalTimezoneID())
   }
 
   def loadBatch(input: ArrowRecordBatch, partitionValues: InternalRow,

--- a/arrow-data-source/standard/src/test/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowDataSourceTest.scala
+++ b/arrow-data-source/standard/src/test/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowDataSourceTest.scala
@@ -286,6 +286,36 @@ class ArrowDataSourceTest extends QueryTest with SharedSparkSession {
 
   }
 
+  test("read and write with case sensitive or insensitive") {
+    val caseSensitiveAnalysisEnabled = Seq[Boolean](true, false)
+    val v1SourceList = Seq[String]("", "arrow")
+    caseSensitiveAnalysisEnabled.foreach{ caseSensitiveAnalysis =>
+      v1SourceList.foreach{v1Source =>
+        withSQLConf(
+          SQLConf.CASE_SENSITIVE.key -> caseSensitiveAnalysis.toString,
+          SQLConf.USE_V1_SOURCE_LIST.key -> v1Source) {
+          withTempPath { tempPath =>
+            spark.range(0, 100)
+              .withColumnRenamed("id", "Id")
+              .write
+              .mode("overwrite")
+              .arrow(tempPath.getPath)
+            val selectColName = if (caseSensitiveAnalysis) {
+              "Id"
+            } else {
+              "id"
+            }
+            val df = spark.read
+              .schema(s"$selectColName long")
+              .arrow(tempPath.getPath)
+              .filter(s"$selectColName <= 2")
+            checkAnswer(df, Row(0) :: Row(1) :: Row(2) :: Nil)
+          }
+        }
+      }
+    }
+  }
+
   test("file descriptor leak") {
     val path = ArrowDataSourceTest.locateResourcePath(parquetFile1)
     val frame = spark.read


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is trying to fix the problem with reading parquet with case sensitive column names. In our scenarios, we have case sensitive column names in parquet, such as `Id7`, and scan parquet with case insensitive mode, which means `id7` whill be pushed down to source, and then we will get 'Id7 not exists'.

## How was this patch tested?
unit tests and additional test.
