### PR TITLE
[NSE-800] Fix an assembly warning

### DIFF
--- a/gazelle-dist/src/main/assembly/assembly.xml
+++ b/gazelle-dist/src/main/assembly/assembly.xml
@@ -22,6 +22,7 @@
       <unpack>true</unpack> <!-- unpack , then repack the jars -->
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>true</useTransitiveFiltering>
+      <useProjectArtifact>false</useProjectArtifact>
       <excludes>
         <!--Exclude jars by specifying groupID:ArtifactID-->
         <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>


### PR DESCRIPTION
This patch will avoid trying to include the artifact for gazelle-dist module in the assembly. Thus, the below build warning can be fixed:

`[WARNING] Cannot include project artifact: com.intel.oap:gazelle-dist:pom:1.4.0-SNAPSHOT; it doesn't have an associated file or directory.`