### PR TITLE
[NSE-956] allow to write parquet with compression

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Install OAP optimized Arrow (C++ libs)
         run: |
           cd /tmp
-          git clone https://github.com/zhouyuan/arrow.git
-          cd arrow && git checkout wip_parquet_write_compression && cd cpp
+          git clone https://github.com/oap-project/arrow.git
+          cd arrow && git checkout arrow-4.0.0-oap && cd cpp
           mkdir build && cd build
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
           sudo make install
@@ -96,8 +96,8 @@ jobs:
       - name: Install OAP optimized Arrow (C++ libs)
         run: |
           cd /tmp
-          git clone https://github.com/zhouyuan/arrow.git
-          cd arrow && git checkout wip_parquet_write_compression && cd cpp
+          git clone https://github.com/oap-project/arrow.git
+          cd arrow && git checkout arrow-4.0.0-oap && cd cpp
           mkdir build && cd build
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
           sudo make install
@@ -141,8 +141,8 @@ jobs:
       - name: Install OAP optimized Arrow (C++ libs)
         run: |
           cd /tmp
-          git clone https://github.com/zhouyuan/arrow.git
-          cd arrow && git checkout wip_parquet_write_compression && cd cpp
+          git clone https://github.com/oap-project/arrow.git
+          cd arrow && git checkout arrow-4.0.0-oap && cd cpp
           mkdir build && cd build
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
           sudo make install

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Install OAP optimized Arrow (C++ libs)
         run: |
           cd /tmp
-          git clone https://github.com/oap-project/arrow.git
-          cd arrow && git checkout arrow-4.0.0-oap && cd cpp
+          git clone https://github.com/zhouyuan/arrow.git
+          cd arrow && git checkout wip_parquet_write_compression && cd cpp
           mkdir build && cd build
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
           sudo make install
@@ -96,8 +96,8 @@ jobs:
       - name: Install OAP optimized Arrow (C++ libs)
         run: |
           cd /tmp
-          git clone https://github.com/oap-project/arrow.git
-          cd arrow && git checkout arrow-4.0.0-oap && cd cpp
+          git clone https://github.com/zhouyuan/arrow.git
+          cd arrow && git checkout wip_parquet_write_compression && cd cpp
           mkdir build && cd build
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
           sudo make install
@@ -141,8 +141,8 @@ jobs:
       - name: Install OAP optimized Arrow (C++ libs)
         run: |
           cd /tmp
-          git clone https://github.com/oap-project/arrow.git
-          cd arrow && git checkout arrow-4.0.0-oap && cd cpp
+          git clone https://github.com/zhouyuan/arrow.git
+          cd arrow && git checkout wip_parquet_write_compression && cd cpp
           mkdir build && cd build
           cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
           sudo make install

--- a/arrow-data-source/common/src/main/scala/com/intel/oap/spark/sql/ArrowWriteQueue.scala
+++ b/arrow-data-source/common/src/main/scala/com/intel/oap/spark/sql/ArrowWriteQueue.scala
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.types.pojo.Schema
 
 import org.apache.spark.internal.Logging
 
-class ArrowWriteQueue(schema: Schema, fileFormat: FileFormat, outputFileURI: String)
+class ArrowWriteQueue(schema: Schema, fileFormat: FileFormat, compressCodec: String, outputFileURI: String)
     extends AutoCloseable with Logging {
   private val scanner = new ScannerImpl(schema)
   private val writeException = new AtomicReference[Throwable]
@@ -52,7 +52,7 @@ class ArrowWriteQueue(schema: Schema, fileFormat: FileFormat, outputFileURI: Str
     val fileName = matcher.group(2)
 
     try {
-      DatasetFileWriter.write(scanner, fileFormat, dirURI, Array(), 1, fileName)
+      DatasetFileWriter.write(scanner, fileFormat, compressCodec, dirURI, Array(), 1, fileName)
     } catch {
       case e: Throwable =>
         writeException.set(e)

--- a/arrow-data-source/script/build_arrow.sh
+++ b/arrow-data-source/script/build_arrow.sh
@@ -62,7 +62,7 @@ echo "ARROW_SOURCE_DIR=${ARROW_SOURCE_DIR}"
 echo "ARROW_INSTALL_DIR=${ARROW_INSTALL_DIR}"
 mkdir -p $ARROW_SOURCE_DIR
 mkdir -p $ARROW_INSTALL_DIR
-git clone https://github.com/oap-project/arrow.git  --branch arrow-4.0.0-oap $ARROW_SOURCE_DIR
+git clone https://github.com/zhouyuan/arrow.git  --branch wip_parquet_write_compression $ARROW_SOURCE_DIR
 pushd $ARROW_SOURCE_DIR
 
 cmake ./cpp \

--- a/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowFileFormat.scala
+++ b/arrow-data-source/standard/src/main/scala/com/intel/oap/spark/sql/execution/datasources/arrow/ArrowFileFormat.scala
@@ -38,6 +38,7 @@ import org.apache.parquet.hadoop.codec.CodecConfig
 import org.apache.parquet.hadoop.util.ContextUtil
 
 import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriterFactory, PartitionedFile}
@@ -50,7 +51,7 @@ import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class ArrowFileFormat extends FileFormat with DataSourceRegister with Serializable {
+class ArrowFileFormat extends FileFormat with DataSourceRegister with Logging with Serializable {
 
 
   override def isSplitable(sparkSession: SparkSession,


### PR DESCRIPTION


## What changes were proposed in this pull request?
This patch adds support for writing parquet with compression

`df.coalesce(1).write.format("arrow").option("parquet.compression","zstd").save(path)`

this patch depends on https://github.com/oap-project/arrow/pull/122

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>
## How was this patch tested?

pass jenkins

