### PR TITLE
[NSE-1032] Adding WSCG check for keys in Join

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -137,7 +137,7 @@ case class ColumnarShuffledHashJoinExec(
       this.supportCodegen = this.supportCodegen && supportCodegen
       if (!supportCodegen) {
         throw new UnsupportedOperationException(
-          "Condition expression is not fully supporting codegen!")
+          "Left or Right key expressions are not fully supporting codegen!")
       }
     }
     // build check for condition

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -128,6 +128,18 @@ case class ColumnarShuffledHashJoinExec(
       case _ =>
         throw new UnsupportedOperationException(s"Join Type ${joinType} is not supported yet.")
     }
+    // build check for leftKeys and rightKeys
+    leftKeys.union(rightKeys).foreach { expr =>
+      val keyExpr =
+        ColumnarExpressionConverter.replaceWithColumnarExpression(expr)
+      val supportCodegen =
+        keyExpr.asInstanceOf[ColumnarExpression].supportColumnarCodegen(null)
+      this.supportCodegen = this.supportCodegen && supportCodegen
+      if (!supportCodegen) {
+        throw new UnsupportedOperationException(
+          "Condition expression is not fully supporting codegen!")
+      }
+    }
     // build check for condition
     val conditionExpr: Expression = condition.orNull
     if (conditionExpr != null) {

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -135,10 +135,6 @@ case class ColumnarShuffledHashJoinExec(
       val supportCodegen =
         keyExpr.asInstanceOf[ColumnarExpression].supportColumnarCodegen(null)
       this.supportCodegen = this.supportCodegen && supportCodegen
-      if (!supportCodegen) {
-        throw new UnsupportedOperationException(
-          "Left or Right key expressions are not fully supporting codegen!")
-      }
     }
     // build check for condition
     val conditionExpr: Expression = condition.orNull


### PR DESCRIPTION
## What changes were proposed in this pull request?
We do a WSCG check in ColumnarShuffledHashJoinExec. But only check the condition, not leftKeys and rightKeys check.
For ExsitingJoin, the condition is null, and there are only leftKeys and rightKeys, which leads to function is currently not supported in WSCG.

## How was this patch tested?
unit tests and manual test.


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

