### PR TITLE
[NSE-1034] Add timeZoneId in ColumnarUnixTimestamp

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarBinaryExpression.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarBinaryExpression.scala
@@ -121,7 +121,7 @@ object ColumnarBinaryExpression {
       case s: DateDiff =>
         new ColumnarDateDiff(left, right)
       case a: UnixTimestamp =>
-        new ColumnarUnixTimestamp(left, right)
+        new ColumnarUnixTimestamp(left, right, a.timeZoneId, a.failOnError)
       // To match GetTimestamp (a private class).
       case _ if (original.isInstanceOf[ToTimestamp] && original.dataType == TimestampType) =>
         // Convert a string to Timestamp. Default timezone is used.

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarDateTimeExpressions.scala
@@ -445,8 +445,12 @@ object ColumnarDateTimeExpressions {
     * The input is the date/time for local timezone (can be configured in spark) and the result is
     * the timestamp for UTC. So we need consider timezone difference.
     * */
-  class ColumnarUnixTimestamp(left: Expression, right: Expression)
-      extends UnixTimestamp(left, right) with
+  class ColumnarUnixTimestamp(
+      left: Expression,
+      right: Expression,
+      timeZoneId: Option[String] = None,
+      failOnError: Boolean = SQLConf.get.ansiEnabled)
+      extends UnixTimestamp(left, right, timeZoneId, failOnError) with
       ColumnarExpression {
 
     val yearMonthDayFormat = "yyyy-MM-dd"


### PR DESCRIPTION
## What changes were proposed in this pull request?
The timeZoneId is resolved in `ResolveTimeZone`, we need add this to `ColumnarUnixTimestamp`. Otherwise, the `resolved` value of `ColumnarUnixTimestamp` will always be false

## How was this patch tested?
manual tests

