### PR TITLE
[NSE-800] Remove spark-arrow-datasource-parquet in assembly

### DIFF
--- a/gazelle-dist/pom.xml
+++ b/gazelle-dist/pom.xml
@@ -60,11 +60,6 @@
     </dependency>
     <dependency>
       <groupId>com.intel.oap</groupId>
-      <artifactId>spark-arrow-datasource-parquet</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intel.oap</groupId>
       <artifactId>spark-arrow-datasource-standard</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
spark-arrow-datasource-parquet is experimental and it is used to override spark's ParquetFileFormat. It should be deployed separately by need.