### PR TITLE
[NSE-1104] fix hashagg w/ empty string

### DIFF
--- a/native-sql-engine/core/src/test/scala/org/apache/spark/sql/nativesql/NativeSQLConvertedSuite.scala
+++ b/native-sql-engine/core/src/test/scala/org/apache/spark/sql/nativesql/NativeSQLConvertedSuite.scala
@@ -368,6 +368,21 @@ class NativeSQLConvertedSuite extends QueryTest
       Row("val1a", Timestamp.valueOf("2014-04-04 01:02:00.001"))))
   }
 
+  test("groupby with empty string") {
+    Seq[(String, Integer, String, String)](
+      ("9", 1, "", "20220608"),
+      ("9", 2, "20220608", ""),
+      ("9", 2, "20220608", ""),
+      ("9", 1, "20220608", ""),
+      ("9", 2, "20220608", ""),
+      ("9", 1, "20220608", ""),
+      ("9", null, "20220608", ""),
+      ("9", 3, "20220608", "")).toDF("a", "b", "c", "d").createOrReplaceTempView("testData")
+    
+    val df1 = sql( "SELECT a,c,d, COUNT(*) FROM testData group by a, c, d")
+    checkAnswer(df1, Seq(Row("9","", "20220608", 1), Row("9","20220608","", 7)))
+  }
+
   test("groupby") {
     Seq[(Integer, java.lang.Boolean)](
       (1, true),

--- a/native-sql-engine/cpp/src/precompile/unsafe_array.h
+++ b/native-sql-engine/cpp/src/precompile/unsafe_array.h
@@ -90,12 +90,10 @@ class TypedUnsafeArray<DataType, enable_if_string_like<DataType>> : public Unsaf
       setNullAt((*unsafe_row).get(), idx_);
     } else {
       auto v = typed_array_->GetView(i);
-      if (v.size() == 0) {
-        arrow::util::string_view split = "\n";
-        appendToUnsafeRow((*unsafe_row).get(), idx_, *(int8_t*)(split.data()));
-        return arrow::Status::OK();
-      }
       switch (v.size()) {
+        case 0:
+          setEmptyAt((*unsafe_row).get(), idx_);
+          break;
         case 1:
           appendToUnsafeRow((*unsafe_row).get(), idx_, *(int8_t*)(v.data()));
           break;

--- a/native-sql-engine/cpp/src/precompile/unsafe_array.h
+++ b/native-sql-engine/cpp/src/precompile/unsafe_array.h
@@ -90,6 +90,11 @@ class TypedUnsafeArray<DataType, enable_if_string_like<DataType>> : public Unsaf
       setNullAt((*unsafe_row).get(), idx_);
     } else {
       auto v = typed_array_->GetView(i);
+      if (v.size() == 0) {
+        arrow::util::string_view split = "\n";
+        appendToUnsafeRow((*unsafe_row).get(), idx_, *(int8_t*)(split.data()));
+        return arrow::Status::OK();
+      }
       switch (v.size()) {
         case 1:
           appendToUnsafeRow((*unsafe_row).get(), idx_, *(int8_t*)(v.data()));

--- a/native-sql-engine/cpp/src/precompile/unsafe_array.h
+++ b/native-sql-engine/cpp/src/precompile/unsafe_array.h
@@ -91,9 +91,6 @@ class TypedUnsafeArray<DataType, enable_if_string_like<DataType>> : public Unsaf
     } else {
       auto v = typed_array_->GetView(i);
       switch (v.size()) {
-        case 0:
-          setEmptyAt((*unsafe_row).get(), idx_);
-          break;
         case 1:
           appendToUnsafeRow((*unsafe_row).get(), idx_, *(int8_t*)(v.data()));
           break;
@@ -107,6 +104,7 @@ class TypedUnsafeArray<DataType, enable_if_string_like<DataType>> : public Unsaf
           appendToUnsafeRow((*unsafe_row).get(), idx_, *(int64_t*)(v.data()));
           break;
         default:
+          // empty string will go here
           appendToUnsafeRow((*unsafe_row).get(), idx_, v);
       }
     }

--- a/native-sql-engine/cpp/src/third_party/row_wise_memory/unsafe_row.h
+++ b/native-sql-engine/cpp/src/third_party/row_wise_memory/unsafe_row.h
@@ -125,6 +125,10 @@ static inline void appendToUnsafeRow(UnsafeRow* row, const int& index, const T& 
 
 static inline void appendToUnsafeRow(UnsafeRow* row, const int& index,
                                      arrow::util::string_view str) {
+  if (unlikely(str.size() == 0)) {
+    setEmptyAt(row, index);
+    return;
+  }
   if (unlikely(row->cursor + str.size() > TEMP_UNSAFEROW_BUFFER_SIZE))
     row->data =
         (char*)nativeRealloc(row->data, 2 * TEMP_UNSAFEROW_BUFFER_SIZE, MEMTYPE_ROW);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes one case of hashagg wrong results over multiple columns
`group by col_a, col_b`
col_a | col_b
-- | --
"ab" | "ab"
"a" | "bab"
"aba" | "b"
"abab" | ""

The fix introduced a new is_empty field to tell whether some columns are empty string, which can fix the issue on last row

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

new unit tests

