### PR TITLE
[NSE-1100] Fall back get_json_object when wildcard is contained in json path

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarBinaryExpression.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarBinaryExpression.scala
@@ -82,6 +82,22 @@ class ColumnarGetJsonObject(left: Expression, right: Expression, original: GetJs
     with ColumnarExpression
     with Logging {
 
+  buildCheck
+
+  // Only literal json path is supported and wildcard is not supported.
+  def buildCheck: Unit = {
+    right match {
+      case literal: ColumnarLiteral =>
+        val jsonPath = literal.value.toString
+        if (jsonPath.contains("*")) {
+          throw new UnsupportedOperationException("Wildcard is NOT supported" +
+            " in json path for get_json_object.")
+        }
+      case _ =>
+        throw new UnsupportedOperationException("Only literal json path is supported!")
+    }
+  }
+
   // TODO: currently we have a codegen implementation, but needs to be optimized.
   override def supportColumnarCodegen(args: java.lang.Object): Boolean = {
     false


### PR DESCRIPTION
The wildcard is not commonly used. So we just fall back to vanilla spark for this case.