### PR TITLE
[NSE-1112] Fix Arrow array meta data validating issue when writing parquet files

### DIFF
--- a/native-sql-engine/cpp/src/operators/row_to_columnar_converter.cc
+++ b/native-sql-engine/cpp/src/operators/row_to_columnar_converter.cc
@@ -185,6 +185,7 @@ inline arrow::Status CreateArrayData(
             null_count++;
           }
         }
+        std::cout << "array_offset[" << row_start + batch_rows << "]:" << array_offset[row_start + batch_rows] << std::endl;
         array->null_count += null_count;
         if (null_count == 0) {
           array->buffers[0] == nullptr;
@@ -292,6 +293,8 @@ arrow::Status RowToColumnarConverter::Init(std::shared_ptr<arrow::RecordBatch>* 
             AllocateBuffer(sizeof(offset_type) * (num_rows_ + 1), m_pool_));
         ARROW_ASSIGN_OR_RAISE(out_data.buffers[2],
                               AllocateResizableBuffer(20 * num_rows_, m_pool_));
+        std::cout << "out_data.buffers[2]->size():" << out_data.buffers[2]->size() << std::endl;
+        std::cout << "out_data.buffers[2]->capacity():" << out_data.buffers[2]->capacity() << std::endl;
         auto validity_buffer = out_data.buffers[0]->mutable_data();
         // initialize all true once allocated
         memset(validity_buffer, 0xff, out_data.buffers[0]->capacity());

--- a/native-sql-engine/cpp/src/operators/row_to_columnar_converter.cc
+++ b/native-sql-engine/cpp/src/operators/row_to_columnar_converter.cc
@@ -149,15 +149,15 @@ inline arrow::Status CreateArrayData(
             int32_t wordoffset = int32_t(offsetAndSize >> 32);
             auto value_offset = array_offset[position + 1] =
                 array_offset[position] + length;
-            uint64_t capacity = array->buffers[2]->capacity();
+            uint64_t size = array->buffers[2]->size();
 
-            if (ARROW_PREDICT_FALSE(value_offset >= capacity)) {
+            if (ARROW_PREDICT_FALSE(value_offset >= size)) {
               // allocate value buffer again
               // enlarge the buffer by 1.5x
-              capacity = capacity + std::max((capacity >> 1), (uint64_t)length);
+              size = size + std::max((size >> 1), (uint64_t)length);
               auto value_buffer =
                   std::static_pointer_cast<arrow::ResizableBuffer>(array->buffers[2]);
-              value_buffer->Reserve(capacity);
+              value_buffer->Resize(size);
               array_data = value_buffer->mutable_data();
             }
 
@@ -186,6 +186,8 @@ inline arrow::Status CreateArrayData(
           }
         }
         std::cout << "array_offset[" << row_start + batch_rows << "]:" << array_offset[row_start + batch_rows] << std::endl;
+        std::cout << "array->buffers[2]->size()" << array->buffers[2]->size() << std::endl;
+        std::cout << "array->buffers[2]->capacity()" << array->buffers[2]->capacity() << std::endl;
         array->null_count += null_count;
         if (null_count == 0) {
           array->buffers[0] == nullptr;

--- a/native-sql-engine/cpp/src/operators/row_to_columnar_converter.cc
+++ b/native-sql-engine/cpp/src/operators/row_to_columnar_converter.cc
@@ -185,9 +185,6 @@ inline arrow::Status CreateArrayData(
             null_count++;
           }
         }
-        std::cout << "array_offset[" << row_start + batch_rows << "]:" << array_offset[row_start + batch_rows] << std::endl;
-        std::cout << "array->buffers[2]->size()" << array->buffers[2]->size() << std::endl;
-        std::cout << "array->buffers[2]->capacity()" << array->buffers[2]->capacity() << std::endl;
         array->null_count += null_count;
         if (null_count == 0) {
           array->buffers[0] == nullptr;
@@ -295,8 +292,6 @@ arrow::Status RowToColumnarConverter::Init(std::shared_ptr<arrow::RecordBatch>* 
             AllocateBuffer(sizeof(offset_type) * (num_rows_ + 1), m_pool_));
         ARROW_ASSIGN_OR_RAISE(out_data.buffers[2],
                               AllocateResizableBuffer(20 * num_rows_, m_pool_));
-        std::cout << "out_data.buffers[2]->size():" << out_data.buffers[2]->size() << std::endl;
-        std::cout << "out_data.buffers[2]->capacity():" << out_data.buffers[2]->capacity() << std::endl;
         auto validity_buffer = out_data.buffers[0]->mutable_data();
         // initialize all true once allocated
         memset(validity_buffer, 0xff, out_data.buffers[0]->capacity());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #1112 .
Still not clear why capacity_ of buffer becomed to the value of size_,
but this patch can fix this issue.


## How was this patch tested?

pass jenkins
