### PR TITLE
[NSE-1116] Disable columnar url_decoder

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -239,6 +239,10 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
 
     }
   }
+
+  val enableUDFKey: String = "spark.oap.sql.columnar.enable.udf"
+  val enableUDF: Boolean =
+    conf.getConfString(enableUDFKey, "true").toBoolean
 }
 
 object GazellePluginConfig {

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/GazellePluginConfig.scala
@@ -242,7 +242,7 @@ class GazellePluginConfig(conf: SQLConf) extends Logging {
 
   val enableUDFKey: String = "spark.oap.sql.columnar.enable.udf"
   val enableUDF: Boolean =
-    conf.getConfString(enableUDFKey, "true").toBoolean
+    conf.getConfString(enableUDFKey, "false").toBoolean
 }
 
 object GazellePluginConfig {

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarUDF.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarUDF.scala
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists
 import com.intel.oap.GazellePluginConfig
 import org.apache.arrow.gandiva.expression.{TreeBuilder, TreeNode}
 import org.apache.arrow.vector.types.pojo.ArrowType
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}

--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarUDF.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarUDF.scala
@@ -18,9 +18,9 @@
 package com.intel.oap.expression
 
 import com.google.common.collect.Lists
+import com.intel.oap.GazellePluginConfig
 import org.apache.arrow.gandiva.expression.{TreeBuilder, TreeNode}
 import org.apache.arrow.vector.types.pojo.ArrowType
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
@@ -88,8 +88,12 @@ object ColumnarUDF {
   // row based function in spark, e.g.,
   // CREATE TEMPORARY FUNCTION UrlDecoder AS 'com.intel.test.URLDecoderNew';
   val supportList = List("urldecoder")
+  val conf = GazellePluginConfig.getSessionConf
 
   def isSupportedUDF(name: String): Boolean = {
+    if (!conf.enableUDF) {
+      return false
+    }
     if (name == null) {
       return false
     }

--- a/native-sql-engine/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/native-sql-engine/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -23,11 +23,11 @@ import java.sql.{Date, Timestamp}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
+import com.intel.oap.GazellePluginConfig
+
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Random
-
 import org.scalatest.matchers.should.Matchers._
-
 import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -604,13 +604,15 @@ class DataFrameSuite extends QueryTest
   }
 
   test("Columnar UDF") {
-    // Register a scala UDF. The scala UDF code will not be acutally used. It
+    // Register a scala UDF. The scala UDF code will not be actually used. It
     // will be replaced by columnar UDF at runtime.
-    spark.udf.register("UrlDecoder", (s : String) => s)
-    checkAnswer(
-      sql("select UrlDecoder('AaBb%23'), UrlDecoder(null)"),
-      Seq(Row("AaBb#", null))
-    )
+    withSQLConf(GazellePluginConfig.getSessionConf.enableUDFKey -> "true") {
+      spark.udf.register("UrlDecoder", (s : String) => s)
+      checkAnswer(
+        sql("select UrlDecoder('AaBb%23'), UrlDecoder(null)"),
+        Seq(Row("AaBb#", null))
+      )
+    }
   }
 
   test("callUDF without Hive Support") {

--- a/native-sql-engine/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/native-sql-engine/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.test
 
 import java.util.{Locale, TimeZone}
 
+import com.intel.oap.GazellePluginConfig
+
 import scala.concurrent.duration._
 import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatest.concurrent.Eventually
@@ -94,6 +96,7 @@ trait SharedSparkSessionBase
     conf.set(
       StaticSQLConf.WAREHOUSE_PATH,
       conf.get(StaticSQLConf.WAREHOUSE_PATH) + "/" + getClass.getCanonicalName)
+    conf.set(GazellePluginConfig.getSessionConf.enableUDFKey, "true")
   }
 
   /**


### PR DESCRIPTION
We added a config to turn on/off columnar UDF. Currently, only url decoder is the supported UDF. So it will only have an impact on this UDF.
@jackylee-ch, please have a review.