### PR TITLE
[NSE-1125] Add status check for hashing GetOrInsert

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
@@ -850,16 +850,16 @@ class HashAggregateKernel::Impl {
           auto aggr_key_validity = !typed_key_in->IsNull(i);
 
           if (aggr_key_validity) {
-            aggr_hash_table_->GetOrInsert(
-                aggr_key, [](int) {}, [](int) {}, &(indices[i]));
+            RETURN_NOT_OK(aggr_hash_table_->GetOrInsert(
+                aggr_key, [](int) {}, [](int) {}, &(indices[i])));
           } else {
             indices[i] = aggr_hash_table_->GetOrInsertNull([](int) {}, [](int) {});
           }
         }
       } else {
         for (int i = 0; i < length; i++) {
-          aggr_hash_table_->GetOrInsert(
-              typed_key_in->GetView(i), [](int) {}, [](int) {}, &(indices[i]));
+          RETURN_NOT_OK(aggr_hash_table_->GetOrInsert(
+              typed_key_in->GetView(i), [](int) {}, [](int) {}, &(indices[i])));
         }
       }
 
@@ -997,9 +997,9 @@ class HashAggregateKernel::Impl {
           }
 
           // FIXME(): all keys are null?
-          aggr_hash_table_->GetOrInsert(
+          RETURN_NOT_OK(aggr_hash_table_->GetOrInsert(
               aggr_key_unsafe_row->data, aggr_key_unsafe_row->cursor, [](int) {},
-              [](int) {}, &(indices[i]));
+              [](int) {}, &(indices[i])));
         }
       } else {
         if (typed_key_in->null_count() > 0) {
@@ -1009,16 +1009,16 @@ class HashAggregateKernel::Impl {
             if (typed_key_in->IsNull(i)) {
               indices[i] = aggr_hash_table_->GetOrInsertNull([](int) {}, [](int) {});
             } else {
-              aggr_hash_table_->GetOrInsert(
-                  aggr_key, [](int) {}, [](int) {}, &(indices[i]));
+              RETURN_NOT_OK(aggr_hash_table_->GetOrInsert(
+                  aggr_key, [](int) {}, [](int) {}, &(indices[i])));
             }
           }
         } else {
           for (int i = 0; i < length; i++) {
             aggr_key = typed_key_in->GetView(i);
 
-            aggr_hash_table_->GetOrInsert(
-                aggr_key, [](int) {}, [](int) {}, &(indices[i]));
+            RETURN_NOT_OK(aggr_hash_table_->GetOrInsert(
+                aggr_key, [](int) {}, [](int) {}, &(indices[i])));
           }
         }
       }
@@ -1161,8 +1161,8 @@ class HashAggregateKernel::Impl {
         if (!aggr_key_validity) {
           memo_index = aggr_hash_table_->GetOrInsertNull([](int) {}, [](int) {});
         } else {
-          aggr_hash_table_->GetOrInsert(
-              aggr_key, [](int) {}, [](int) {}, &memo_index);
+          RETURN_NOT_OK(aggr_hash_table_->GetOrInsert(
+              aggr_key, [](int) {}, [](int) {}, &memo_index));
         }
 
         if (memo_index > max_group_id_) {

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -88,7 +88,8 @@ class EncodeArrayTypedImpl : public EncodeArrayKernel::Impl {
     if (typed_array->null_count() == 0) {
       for (; cur_id < typed_array->length(); cur_id++) {
         RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id),
-         insert_on_found, insert_on_not_found, &memo_index));
+                                               insert_on_found, insert_on_not_found,
+                                               &memo_index));
       }
     } else {
       for (; cur_id < typed_array->length(); cur_id++) {
@@ -96,7 +97,8 @@ class EncodeArrayTypedImpl : public EncodeArrayKernel::Impl {
           hash_table_->GetOrInsertNull(insert_on_found, insert_on_not_found);
         } else {
           RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id),
-           insert_on_found, insert_on_not_found, &memo_index));
+                                                 insert_on_found, insert_on_not_found,
+                                                 &memo_index));
         }
       }
     }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -87,16 +87,16 @@ class EncodeArrayTypedImpl : public EncodeArrayKernel::Impl {
     int memo_index = 0;
     if (typed_array->null_count() == 0) {
       for (; cur_id < typed_array->length(); cur_id++) {
-        hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
-                                 insert_on_not_found, &memo_index);
+        RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
+                                 insert_on_not_found, &memo_index));
       }
     } else {
       for (; cur_id < typed_array->length(); cur_id++) {
         if (typed_array->IsNull(cur_id)) {
           hash_table_->GetOrInsertNull(insert_on_found, insert_on_not_found);
         } else {
-          hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
-                                   insert_on_not_found, &memo_index);
+          RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
+                                   insert_on_not_found, &memo_index));
         }
       }
     }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -87,16 +87,16 @@ class EncodeArrayTypedImpl : public EncodeArrayKernel::Impl {
     int memo_index = 0;
     if (typed_array->null_count() == 0) {
       for (; cur_id < typed_array->length(); cur_id++) {
-        RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
-                                 insert_on_not_found, &memo_index));
+        RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id),
+         insert_on_found, insert_on_not_found, &memo_index));
       }
     } else {
       for (; cur_id < typed_array->length(); cur_id++) {
         if (typed_array->IsNull(cur_id)) {
           hash_table_->GetOrInsertNull(insert_on_found, insert_on_not_found);
         } else {
-          RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id), insert_on_found,
-                                   insert_on_not_found, &memo_index));
+          RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id),
+           insert_on_found, insert_on_not_found, &memo_index));
         }
       }
     }

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/probe_kernel.cc
@@ -1127,8 +1127,8 @@ class TypedProberImpl : public CodeGenBase {
     int memo_index = 0;
     if (typed_array->null_count() == 0) {
       for (; cur_id_ < typed_array->length(); cur_id_++) {
-        hash_table_->GetOrInsert(typed_array->GetView(cur_id_), [](int32_t){},
-                                 [](int32_t){}, &memo_index);
+        RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id_), [](int32_t){},
+                                 [](int32_t){}, &memo_index));
         if (memo_index < num_items_) {
           insert_on_found(memo_index);
         } else {
@@ -1140,9 +1140,9 @@ class TypedProberImpl : public CodeGenBase {
         if (typed_array->IsNull(cur_id_)) {
           hash_table_->GetOrInsertNull([](int32_t){}, [](int32_t){});
         } else {
-          hash_table_->GetOrInsert(typed_array->GetView(cur_id_),
+          RETURN_NOT_OK(hash_table_->GetOrInsert(typed_array->GetView(cur_id_),
                                    [](int32_t){}, [](int32_t){},
-                                   &memo_index);
+                                   &memo_index));
         if (memo_index < num_items_) {
           insert_on_found(memo_index);
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Index returns -1 when HashMap.GetOrInsert failed with some problems such as buffer overflow or OOM. And it whould finally core dump when trying to use this index.
Here we add a status check and throw exception if it failed.

## How was this patch tested?
unit tests.

