### PR TITLE
[NSE-1127] Use larger buffer for hash agg

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_aggregate_kernel.cc
@@ -45,7 +45,7 @@ namespace codegen {
 namespace arrowcompute {
 namespace extra {
 using ArrayList = std::vector<std::shared_ptr<arrow::Array>>;
-using precompile::StringHashMap;
+using precompile::LargeStringHashMap;
 
 ///////////////  HashAgg Kernel  ////////////////
 class HashAggregateKernel::Impl {
@@ -945,7 +945,7 @@ class HashAggregateKernel::Impl {
           pre_process_projector_(pre_process_projector),
           post_process_projector_(post_process_projector),
           action_impl_list_(action_impl_list) {
-      aggr_hash_table_ = std::make_shared<StringHashMap>(ctx->memory_pool());
+      aggr_hash_table_ = std::make_shared<LargeStringHashMap>(ctx->memory_pool());
 #ifdef DEBUG
       std::cout << "using string hashagg res" << std::endl;
 #endif
@@ -1072,7 +1072,7 @@ class HashAggregateKernel::Impl {
    private:
     arrow::compute::ExecContext* ctx_;
     std::vector<std::shared_ptr<ActionBase>> action_impl_list_;
-    std::shared_ptr<StringHashMap> aggr_hash_table_;
+    std::shared_ptr<LargeStringHashMap> aggr_hash_table_;
     const std::vector<int>& key_index_list_;
     const std::vector<std::vector<int>>& action_prepare_index_list_;
     std::shared_ptr<GandivaProjector> pre_process_projector_;

--- a/native-sql-engine/cpp/src/precompile/hash_map.cc
+++ b/native-sql-engine/cpp/src/precompile/hash_map.cc
@@ -113,6 +113,8 @@ TYPED_ARROW_HASH_MAP_IMPL(Date32HashMap, Date32Type, int32_t, Date32MemoTableTyp
 TYPED_ARROW_HASH_MAP_IMPL(Date64HashMap, Date64Type, int64_t, Date64MemoTableType)
 TYPED_ARROW_HASH_MAP_BINARY_IMPL(StringHashMap, StringType, arrow::util::string_view,
                                  StringMemoTableType)
+TYPED_ARROW_HASH_MAP_BINARY_IMPL(LargeStringHashMap, LargeStringType,
+                                 arrow::util::string_view, LargeStringMemoTableType)
 TYPED_ARROW_HASH_MAP_DECIMAL_IMPL(Decimal128HashMap, Decimal128Type, arrow::Decimal128,
                                   DecimalMemoTableType)
 #undef TYPED_ARROW_HASH_MAP_IMPL

--- a/native-sql-engine/cpp/src/precompile/hash_map.h
+++ b/native-sql-engine/cpp/src/precompile/hash_map.h
@@ -47,6 +47,7 @@ TYPED_HASH_MAP_DEFINE(DoubleHashMap, double)
 TYPED_HASH_MAP_DEFINE(Date32HashMap, int32_t)
 TYPED_HASH_MAP_DEFINE(Date64HashMap, int64_t)
 TYPED_HASH_MAP_DEFINE(StringHashMap, arrow::util::string_view)
+TYPED_HASH_MAP_DEFINE(LargeStringHashMap, arrow::util::string_view)
 TYPED_HASH_MAP_DEFINE(Decimal128HashMap, arrow::Decimal128)
 #undef TYPED_HASH_MAP_DEFINE
 }  // namespace precompile


### PR DESCRIPTION
## What changes were proposed in this pull request?
Current hash aggegate use `StringHashMap` to build hash table, which actually use `StringBuilder` to storage keys and its size is limited to `Int.max-1`. We meet the problem with `Capacity error: array cannot contain more than 2147483646 bytes, have 2147483708` while using aggeragate, it shows the origin buffer in hash map for hash aggerate is overflowed. 
Thus, we use `LargeStringHashMap` to build hash table, which use `LargeBinaryBuilder` to storage keys and its size is limited to `Long.max-1`.

## How was this patch tested?
unit tests.

