### PR TITLE
[NSE-1114] Remove temp directory without FileUtils.forceDeleteOnExit

### DIFF
--- a/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
+++ b/native-sql-engine/core/src/main/java/com/intel/oap/vectorized/JniUtils.java
@@ -82,7 +82,8 @@ public class JniUtils {
         } else {
           Path folder = Paths.get(_tmp_dir);
           Path path = Files.createTempDirectory(folder, "spark_columnar_plugin_");
-          FileUtils.forceDeleteOnExit(new File(path.toUri()));
+          Runtime.getRuntime().addShutdownHook(
+              new Thread(() -> FileUtils.deleteQuietly(path.toFile())));
           tmp_dir = path.toAbsolutePath().toString();
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
FileUtils.forceDeleteOnExit won't delete the files that are added after function calls, and it will fail to delete the directory. Thus we add new hook to delete the directory.

## How was this patch tested?
unit tests.

