### PR TITLE
[NSE-1141] Replace ValueOrDie with status check to avoid executor die

### DIFF
--- a/native-sql-engine/cpp/src/codegen/common/relation_column.h
+++ b/native-sql-engine/cpp/src/codegen/common/relation_column.h
@@ -54,7 +54,11 @@ class LazyBatchIterator {
 
   bool AdvanceTo(int32_t batch_id) {
     for (; current_batch_id_ <= batch_id; current_batch_id_++) {
-      std::shared_ptr<arrow::RecordBatch> next = in_.Next().ValueOrDie();
+      auto result = in_.Next();
+      if (!result.ok()) {
+        throw JniPendingException("Get next batch failed.");
+      }
+      std::shared_ptr<arrow::RecordBatch> next = result.ValueUnsafe();
       if (next == nullptr) {
         return false;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently we use ValueOrDie to check the status, such as LazyBatchIterator.AdvanceTo, and it will directly hang up the current process if there is an exception caused bad status. However, in many cases, it is sufficient to just throw an exception rather than hang up the process, such as the FetchFailedException, which means fetch block failed from other executor. And for Spark, the hanging of the executor process is much more serious than throwing exception, because this will lead to a large number of task recalculations, which may lead to more serious problems.

## How was this patch tested?
unit tests and manual tests.
