### PR TITLE
[NSE-1196] Fix: concat with only one expression

### DIFF
--- a/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarConcatOperator.scala
+++ b/native-sql-engine/core/src/main/scala/com/intel/oap/expression/ColumnarConcatOperator.scala
@@ -118,6 +118,12 @@ class ColumnarConcat(exps: Seq[Expression], original: Expression)
   }
 
   override def doColumnarCodeGen(args: java.lang.Object): (TreeNode, ArrowType) = {
+    if (exps.size == 1) {
+      val (exp_node, expType): (TreeNode, ArrowType) =
+        exps.head.asInstanceOf[ColumnarExpression].doColumnarCodeGen(args)
+      return (exp_node, expType)
+    }
+
     val iter: Iterator[Expression] = exps.iterator
     val exp = iter.next()
     val iterFaster: Iterator[Expression] = exps.iterator


### PR DESCRIPTION
## What changes were proposed in this pull request?
Concat with only one expression is not supported yet. here is a little sample, `select concat(expr) from table`

closes: #1196 
## How was this patch tested?
unit tests.

